### PR TITLE
Fix map usage in traversal esig

### DIFF
--- a/gunfolds/solvers/traversal.py
+++ b/gunfolds/solvers/traversal.py
@@ -1694,7 +1694,13 @@ def esig(l, n):
     :rtype: integer
     """
     z = len(str(n))
-    n = map(lambda x: ''.join(map(lambda y: str(y).zfill(z), x)), l)
+    # ``map`` returns an iterator in Python 3, so we need to materialise
+    # the results before sorting. In Python 2 the original code relied on
+    # ``map`` returning a list which is mutable and sortable. Without
+    # converting to ``list`` a ``map`` object would raise an ``AttributeError``
+    # when ``sort`` is called.  By wrapping ``map`` with ``list`` we ensure
+    # compatibility with both versions of Python.
+    n = list(map(lambda x: ''.join(map(lambda y: str(y).zfill(z), x)), l))
     n.sort()
     n = ''.join(n[::-1])
     return int('1' + n)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -362,7 +362,7 @@ class TestTraversalFunctions(unittest.TestCase):
                  (4, 2, 4), (1, 2, 4), (2, 1, 3),
                  (1, 1, 3), (5, 4), (5, 1, 3), (3, 1, 3),
                  (4, 1, 3)]
-        expected = (30112680, 1545134244133543132542131241130322L)
+        expected = (30112680, 1545134244133543132542131241130322)
         self.assertEqual(expected, traversal.signature(self.G1, edges))
 
     def test__inorder_check2(self):


### PR DESCRIPTION
## Summary
- fix `esig` map usage for Python3 compatibility
- update tests for Python3

## Testing
- `python -m tests.tests` *(fails: ValueError, TypeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6848a067769883249328ab59b7f2dc44