### PR TITLE
Scc edge acyclic quotient

### DIFF
--- a/CHANGELOG_AI.md
+++ b/CHANGELOG_AI.md
@@ -5,6 +5,36 @@ Short summaries of code and documentation changes made via Cursor AI sessions.
 
 ## 2026-05-04  (branch: current)
 
+### SCC encoding fix: `dag/3` → `scc_edge/3` rename + acyclic-quotient via back-edge dropping (todo item #1)
+
+**Two-part change in `gunfolds/conversions.py`.**
+
+1. **Rename `dag/3` → `scc_edge/3`** in the three sites that emit/consume the predicate inside `encode_sccs` and `encode_list_sccs`. The old name was misleading because the relation is the SCC quotient digraph of the measured graph, not a DAG in general.
+
+2. **Acyclic-quotient enforcement via back-edge dropping (no class merging).** When `scc_members` is supplied (the production path with `--scc_strategy=domain` / `correlation`), the partition is hand-specified by NeuroMark domain or correlation cluster and may *split* a real SCC across multiple classes — producing a cyclic quotient. New helper `_acyclic_quotient_edges(glist, partition)` builds the quotient over the union of `glist`, finds its SCCs, and **drops only the back-edges within each cyclic SCC of the quotient** (sorted by class index for a deterministic forward direction). Every input class is preserved as its own SCC in the encoding. `encode_sccs` now accepts an optional `quotient_edges` override that bypasses NetworkX's `condensation` and emits the precomputed acyclic edge set verbatim.
+
+**Why this design over the merge alternative.** Merging classes within each cyclic quotient-SCC is theoretically sounder (it gives a true SCC coarsening), but on real fMRI data every NeuroMark domain pair has bidirectional flow at PCMCI alpha=0.05, so the merge collapses the 7-class partition to a single SCC and the SCC integrity constraints become vacuous (no class-distinct pairs to constrain). The user explicitly opted for the speed-vs-soundness lever: keep the partition, drop back-edges, accept that the constraint may now reject some valid causal graphs whose arrows go in dropped directions. This preserves per-SCC pruning power and keeps per-SCC decomposition meaningful as a future speedup.
+
+**Empirical results (FBIRN N=10 subject 1, `--optim opt`, `density_mode='hard_soft0'`).**
+
+| Variant | Solve time | Optimum | Sound? |
+|---|---|---|---|
+| Original cyclic encoding | 1.43 s | `[340, 350]` | ❌ — cycles let invalid arrows pass |
+| Merge cyclic classes | 120 s timeout (descending past `[302, 350]`) | < `[302, 350]` | ✅ but vacuous on fMRI |
+| **Drop back-edges (this fix)** | **0.03 s** | `[452, 350]` | ⚠️ technically unsound (drops valid arrows) |
+
+Subject 0 N=10 domain partition `[{1,2}, {3}, {4}, {5}, {6,7}, {8,9}, {10}]` is preserved; the fix drops 14 back-edges out of 22 quotient edges and emits the remaining 8 forward arrows. Synthetic `[{1}, {2,3}, {4}]` over `1→2→3→1, 4→3` similarly preserves all 3 classes and drops 1 back-edge.
+
+The reported optimum cost rises from `[340, 350]` to `[452, 350]` because the new encoding is *more* restrictive than the original. The original's lower 340 was a phantom: cycles in the old `dag/3` quotient allowed cross-class arrows that should have been forbidden — so half the prior "optima" violated the SCC invariant. **All prior fMRI optimization numbers measured against `--scc_strategy=domain` should be regenerated** before being cited.
+
+**Per-SCC decomposition (future).** With the partition now preserved, per-SCC decomposition becomes a meaningful next-step speedup: solve each SCC's sub-problem independently in Python, then combine. Not implemented in this change.
+
+**Out-of-scope finding.** `clingo_rasl.py:425` emits a `dagl(N-1)` fact never consumed by any rule. Pure dead code. Left for a separate cleanup PR.
+
+**Files:** `gunfolds/conversions.py` (rename + new `_acyclic_quotient_edges` helper + `quotient_edges` parameter on `encode_sccs` + updated docstrings); `gunfolds/scripts/papers/example_clingo.md` (predicate name updated to match emitter); `todo.md` (item 1 moved to Done).
+
+---
+
 ### Domain heuristic + PCMCI-prior `#heuristic` directives — tested and REJECTED (suggestion #4)
 
 New benchmark script `gunfolds/scripts/tests/benchmark_domain_heuristic.py` tests the only remaining untested clasp branching/heuristic knob from `clingo_speedup_suggestions.md`: emit `#heuristic edge1(X,Y). [W,true|false]` directives keyed off PCMCI's DD weights and run clasp with `--heuristic=Domain` (and a variant with `--dom-mod=5,16`). Built against the production encoding (`density_mode='hard_soft0'`, `tol_low=15, tol_high=5`).

--- a/CHANGELOG_AI.md
+++ b/CHANGELOG_AI.md
@@ -3,6 +3,17 @@
 Short summaries of code and documentation changes made via Cursor AI sessions.
 
 
+## 2026-05-28  (branch: current)
+
+### Fixed clingo stats reporting (always 0) + new solve-phase fingerprint; solver-strategy axis closed
+
+`benchmark_density_encoding.py` read `solving.solvers[0]` for CDCL counters, but clingo 5.7.1 puts aggregates on `solving.solvers.{choices,conflicts,restarts}` (per-thread is `solving.solver[i]`, singular). `_sg` swallowed the `TypeError`/`KeyError`, so every run printed `choices=0 conflicts=0 restarts=0` — a reporting glitch only; all prior costs/timings were correct. Fixed the path, added `--stats=2` and `extra.{lemmas,domain_choices}`, and added a trajectory **phase fingerprint** (`pre_first/descent/proof_tail` + rates) with new result fields and summary columns.
+
+Using the fixed counters: default `bb,lin` beats every alternative; `bb,hier`/`bb,dec` slower; `usc,oll` times out with **0 bound improvement** at both 10-thread *and* single-thread (8 M / 476 K conflicts, no feasible model) — re-confirms the prior USC rejection and makes its failure mode visible for the first time. The ~70–90 % proof tail at N=10 is intrinsic; **no clasp flag helps**. Remaining levers are encoding-level (todo #6/#7) or structural (todo #3), to be decided by running the fingerprint at N=14/20. todo item #2 → Done.
+
+**Files:** `gunfolds/scripts/tests/benchmark_density_encoding.py`, `todo.md`.
+
+
 ## 2026-05-27  (branch: current)
 
 ### runtime_scaling: stable-matrix sampling strategies + large-N resubmit script

--- a/CHANGELOG_AI.md
+++ b/CHANGELOG_AI.md
@@ -3,6 +3,38 @@
 Short summaries of code and documentation changes made via Cursor AI sessions.
 
 
+## 2026-05-27  (branch: current)
+
+### runtime_scaling: stable-matrix sampling strategies + large-N resubmit script
+
+Diagnosed the `Could not find stable matrix after 1,000,000 tries` failure: ρ(random sparse W) grows like √(N·density), so the post-`0.99/ρ` rescale shrinks entries as 1/√N and the path-strength filter rejects nearly every draw at large N.
+
+Added five composable strategies to `create_stable_weighted_matrix` in `runtime_scaling.py`: `scale_aware` (σ = 1/√⟨in-deg⟩, on by default), `bias_magnitudes`, `auto_threshold`, configurable `powers`, and a new deterministic `construct_stable_matrix_from_sccs(A, partition)` (block-triangular, zero rejection, ρ < 1 by construction). Plus `get_stable_weighted_matrix(...)` dispatcher and CLI flags `--w_strategy`, `--w_threshold`, `--w_powers`, `--w_scale_aware`/`--w_no_scale_aware`, `--w_bias_magnitudes`, `--w_auto_threshold`. All strategies succeed in < 3 ms at N=24, 36, 54 in standalone tests.
+
+New `submit_runtime_scaling_large.sh`: one instance each at N=30/42/54 with max walltime `5-08:00:00`, `--timeout_hours=127`, `--w_bias_magnitudes`. Memory + CPUs sized so `mem/cpu ≤ 15 GB` (qTRDGPU MaxMemPerCPU), avoiding the silent CPU bump the old N=54 run hit: N=30 → 160 GB/11 cpus, N=42 → 256 GB/18 cpus, N=54 → 480 GB/32 cpus.
+
+**Files:** `gunfolds/scripts/experiments/runtime_scaling.py`, `gunfolds/scripts/experiments/submit_runtime_scaling_large.sh` (new).
+
+
+## 2026-05-07  (branch: current)
+
+### New experiment + three library-bug workarounds + checklist updates
+
+**New experiment** in `gunfolds/scripts/experiments/`: `runtime_scaling.py` (one job per `(N, instance_id)`: build multi-SCC ring G¹ → VAR + BOLD → PCMCI `tau_max=1,alpha=0.05` → drasl with `threading.Timer` interrupt → F1), `submit_runtime_scaling.sh` (100 jobs, skip-if-completed/queued guards), `aggregate_results.py`, `check_status.sh`. SCC compositions: `N=8→[6,2], 10→[6,4], 12→[6,6], 14→[6,4,4], 18→[6,6,6], 20→[6,6,4,4], 24..54=[6]*k`. Headline medians: N=8 → 0.2 s, N=10 → 2.9 s, N=12 → 1.6 min, N=14 → 1.4 min, N=18 → 50 min, N=20 → 8.9 h.
+
+**Three caller-side workarounds for gunfolds bugs** (upstream issues filed):
+
+1. `gk.randomDAG` infinite-loops for `N ≤ 2` (`remove_tril_singletons` off-by-one); replaced with a hand-rolled `nx.DiGraph` chain in `make_multi_scc_ring`.
+2. `simulate_bold` ignored `u_rate` because `end_time=100` was fixed; now passes `end_time=100*u_rate`.
+3. `compute_bold_signals` returns a ragged 1-D object array when scipy `vode` fails on one node; detect `ndim == 1` and retry with tighter input rescaling.
+
+**Cluster-ops lessons:** `sbatch --wrap` runs under `/bin/sh` (dash) so `source` must be `.` or prepend `#!/bin/bash`; `qTRDGPU` enforces `MaxMemPerCPU≈15.2 GB` and silently bumps `--cpus-per-task` to satisfy the ratio; `clingo -n 1 --opt-mode=opt` returns the first feasible model, not the optimum — use `-n 0`.
+
+**Checklist skill updates** (`~/.claude/skills/checklist/SKILL.md`): item 16 (`simulate_bold` end_time scaling), item 17 (never call `gk.randomDAG` when `num_sccs ≤ 2`), mandatory `_assert_glag2cg_direction()` sanity check under item 2.
+
+**Files:** `gunfolds/scripts/experiments/{runtime_scaling.py,submit_runtime_scaling.sh,aggregate_results.py,check_status.sh}` (all new); `~/.claude/skills/checklist/SKILL.md`.
+
+
 ## 2026-05-04  (branch: current)
 
 ### SCC quotient back-edge selection: weighted MFAS via igraph `exact_ip` (Option C)

--- a/CHANGELOG_AI.md
+++ b/CHANGELOG_AI.md
@@ -5,6 +5,30 @@ Short summaries of code and documentation changes made via Cursor AI sessions.
 
 ## 2026-05-04  (branch: current)
 
+### SCC quotient back-edge selection: weighted MFAS via igraph `exact_ip` (Option C)
+
+Replaces the class-index-ordering criterion in `_acyclic_quotient_edges` (introduced in `0079ca60`) with a principled minimum-weight feedback arc set (MFAS) using exact integer programming via `python-igraph`'s `Graph.feedback_arc_set(method='exact_ip')`.
+
+**Edge weight definition** (uses *all* available PCMCI signal, per the user's design ask). For each candidate cross-class arrow `K → L`:
+
+```
+w(K → L) = pos(K → L) + neg(L → K)
+```
+
+where `pos(K → L)` is the total `hdirected` weight summed across `(X ∈ K, Y ∈ L)` node pairs that PCMCI judges present, and `neg(L → K)` is the total `no_hdirected` weight summed across `(Y ∈ L, X ∈ K)` node pairs that PCMCI judges absent. The first term penalises dropping arrows that PCMCI directly supports; the second penalises drops that would force the encoding into the reverse direction, which `no_hdirected` facts contradict. The minimum-weight feedback arc set returned by igraph's exact ILP solver is the principled drop set: minimum number of edges (NP-hard in general, trivial at our 7-node quotient size) and minimum total PCMCI evidence cost.
+
+**Headline result on FBIRN N=10 subject 0** (NeuroMark domain partition → cyclic 7-class quotient with 22 internal edges): class-index fallback dropped 14 back-edges keeping 8 quotient edges; weighted MFAS drops only **5 back-edges keeping 17** (77% retention) with a total evidence cost of 142. The number of dropped edges is provably minimum at this scale; the choice of *which* 5 minimises lost PCMCI evidence.
+
+**Empirical impact on subject 1 N=10 baseline:** solve time effectively unchanged (0.04 s vs prior 0.03 s). Optimum cost descends from `[452, 350]` to `[423, 350]` — expected and correct: keeping 17 quotient edges instead of 8 gives the solver more freedom (the SCC integrity constraints fire less often), so a lower-cost graph becomes reachable. The encoding is *less* restrictive than the class-index fallback but *more principled* — it only drops the cycle-creating back-edges that are necessary, weighted by PCMCI confidence. Compared to the original cyclic encoding (which optimum was `[340, 350]`, an unsound phantom), this 423 is sound modulo the speed-vs-soundness lever already documented (we still drop *some* valid cross-class arrows; just the minimum-evidence-cost subset).
+
+**Backward compatibility.** When `dm` is not supplied to `encode_list_sccs` (legacy callers), `_acyclic_quotient_edges` falls back to the class-index ordering. `drasl_command` always has `dm` available and now passes it through.
+
+**Logged for future.** Bayesian log-likelihood-ratio weights (Option D from the design discussion) requires calibrating DD weights against actual probability scales and is captured in `todo.md` item #7. Suggestion #9 ground-reduction trick (drop weight-0 facts) is captured in `todo.md` item #6 — to measure first before implementing.
+
+**Files:** `gunfolds/conversions.py` (`_acyclic_quotient_edges` gains `dm` parameter and weighted-MFAS path; `encode_list_sccs` plumbs `dm` through; updated docstrings). `gunfolds/solvers/clingo_rasl.py` (passes `dm` to `encode_list_sccs`). `gunfolds/scripts/papers/scc_quotient_edge_dropping_research.md` (new — local-only research doc with literature review, weight-function options A–D, and the Option C derivation). `todo.md` (items 6 and 7 added).
+
+---
+
 ### SCC encoding fix: `dag/3` → `scc_edge/3` rename + acyclic-quotient via back-edge dropping (todo item #1)
 
 **Two-part change in `gunfolds/conversions.py`.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Key contributions I built:
 - **RnR** — A meta-solver that refines the output of *any* causal discovery
   algorithm by modeling undersampling effects via ASP. Improves F1 by 45%
   over SOTA baselines (PCMCI, FASK, MVGC, GIMME) on real fMRI data.
-  Under review at ICML 2026.
+  Under review at NeurIPS 2026.
 
 - **ION-C** — Causal learning from overlapping datasets with non-co-measured
   variables. Proved soundness and completeness; scales from 4–6 nodes

--- a/gunfolds/conversions.py
+++ b/gunfolds/conversions.py
@@ -822,7 +822,7 @@ def encode_sccs(g, idx, components=True, SCCS=None, quotient_edges=None):
     return s
 
 
-def _acyclic_quotient_edges(glist, partition):
+def _acyclic_quotient_edges(glist, partition, dm=None):
     """
     Compute the per-graph quotient edges for ``partition`` over ``glist``,
     with cycles broken to keep the ``scc_edge/3`` relation acyclic *without*
@@ -861,21 +861,55 @@ def _acyclic_quotient_edges(glist, partition):
     3. Find SCCs of ``Q``.  Edges between distinct SCCs of ``Q`` are
        always one-directional (otherwise the two SCCs would be a single
        SCC), so they are kept verbatim.  Edges within a non-trivial SCC
-       of ``Q`` are filtered: we pick a deterministic within-SCC class
-       order (sorted by class index) and keep only forward edges.
+       of ``Q`` are filtered: we pick a back-edge set for removal as
+       described below.
     4. Apply the same per-class forward filter to each graph in
        ``glist`` independently to produce the final ``(K, L, idx)``
        triples.
 
+    Back-edge selection
+    -------------------
+    Two strategies, picked at runtime based on ``dm``:
+
+    - **Weighted MFAS (preferred, ``dm`` provided).**  For each cyclic SCC
+      of ``Q``, run an exact integer-programming Minimum Feedback Arc Set
+      with edge weights derived from the PCMCI evidence.  For class pair
+      ``(K, L)`` the drop cost is
+
+      ``w(K -> L) = pos(K -> L) + neg(L -> K)``
+
+      where ``pos(K -> L)`` is the total ``hdirected`` weight of node-pair
+      arrows from class K to class L (sum of ``dm[g_idx][X-1, Y-1]`` over
+      ``X in K, Y in L`` with ``g[X][Y] in {1, 3}``), and ``neg(L -> K)``
+      is the total ``no_hdirected`` weight in the *reverse* direction
+      (sum over ``Y in L, X in K`` with ``g[Y][X] not in {1, 3}``).  This
+      uses both signals the user identified — evidence supporting the
+      arrow we'd drop and evidence against the arrow we'd keep instead —
+      and minimises the total evidence cost of the drops.  See
+      ``gunfolds/scripts/papers/scc_quotient_edge_dropping_research.md``
+      for the literature review and the rationale for this choice over
+      Bayesian-ratio alternatives (logged in ``todo.md`` for future).
+    - **Class-index ordering (fallback, ``dm`` is None).**  Sort the
+      classes within each cyclic SCC by their integer class index and
+      keep only forward edges.  Used when callers do not supply ``dm``,
+      preserving backward compatibility.
+
     :param glist: list of measured graphs (gunfolds 1-indexed dicts).
     :param partition: list of node-id sets — one per class.
+    :param dm: optional list of NxN integer matrices, one per graph in
+        ``glist``, holding the directed-edge PCMCI weights (``DD`` from
+        the standard recipe).  When provided, weighted MFAS is used to
+        pick back-edges; otherwise class-index fallback is used.
+    :type dm: list of numpy.ndarray, or None
 
-    :returns: a tuple ``(triples, n_dropped)``:
+    :returns: a tuple ``(triples, n_dropped, weight_dropped)``:
         ``triples`` is a deduplicated list of ``(K, L, idx)`` triples to
         emit as ``scc_edge`` facts (idx is 1-based);
         ``n_dropped`` is the number of distinct ``(K, L)`` quotient edges
         that were dropped to break cycles (0 means the partition's
-        quotient was already a DAG).
+        quotient was already a DAG);
+        ``weight_dropped`` is the total MFAS weight cost of the drops
+        (0 in the unweighted fallback path).
     """
     H = nx.DiGraph()
     for g in glist:
@@ -901,27 +935,92 @@ def _acyclic_quotient_edges(glist, partition):
             continue
         Q.add_edge(ku, kv)
 
-    # For each non-trivial SCC of Q, fix a within-SCC order so that we
-    # can drop back-edges deterministically.  Singleton SCCs of Q play no
-    # role (no internal back-edges possible).
+    # Identify SCCs of Q.  Singleton SCCs play no role (no internal
+    # back-edges possible).  Non-singleton SCCs are exactly the cycles
+    # we need to break.
     class_qscc = {}
-    within_qscc_pos = {}
+    qscc_members = {}
     for q_idx, comp in enumerate(strongly_connected_components(Q)):
-        for pos, cls in enumerate(sorted(comp)):
+        members = set(comp)
+        qscc_members[q_idx] = members
+        for cls in members:
             class_qscc[cls] = q_idx
-            within_qscc_pos[cls] = pos
 
-    # Count dropped quotient edges (distinct (K, L) pairs over the union).
-    union_edges = set(Q.edges())
-    dropped_edges = {
-        (u, v) for (u, v) in union_edges
-        if class_qscc[u] == class_qscc[v]
-        and within_qscc_pos[u] >= within_qscc_pos[v]
-    }
+    # Decide which back-edges to drop, using weighted MFAS when we have
+    # PCMCI weights and class-index fallback otherwise.
+    dropped_edges = set()
+    weight_dropped = 0
+
+    if dm is not None:
+        # Weighted MFAS via igraph's exact_ip.  Pre-compute pos/neg per
+        # class pair (only for pairs we may need — i.e. those inside a
+        # non-trivial SCC of Q).
+        cyclic_classes = set()
+        for q_idx, members in qscc_members.items():
+            if len(members) > 1:
+                cyclic_classes |= members
+        if cyclic_classes:
+            pos_evidence = {}  # (K, L) -> int
+            neg_evidence = {}  # (K, L) -> int
+            for K in cyclic_classes:
+                for L in cyclic_classes:
+                    if K == L:
+                        continue
+                    p, n_ev = 0, 0
+                    for g_idx, g in enumerate(glist):
+                        M = dm[g_idx]
+                        for x in partition[K]:
+                            row_x = M[x - 1]
+                            adj_x = g.get(x, {})
+                            for y in partition[L]:
+                                w = int(row_x[y - 1])
+                                if adj_x.get(y, 0) in (1, 3):
+                                    p += w
+                                else:
+                                    n_ev += w
+                    pos_evidence[(K, L)] = p
+                    neg_evidence[(K, L)] = n_ev
+
+            for q_idx, members in qscc_members.items():
+                if len(members) <= 1:
+                    continue
+                # Collect internal edges of this cyclic SCC.
+                internal = [(u, v) for u, v in Q.edges()
+                            if u in members and v in members]
+                if not internal:
+                    continue
+                # Local class indexing for the igraph subgraph.
+                cls_list = sorted(members)
+                cls_to_local = {c: i for i, c in enumerate(cls_list)}
+                local_edges = [(cls_to_local[u], cls_to_local[v])
+                               for (u, v) in internal]
+                weights = [pos_evidence[(u, v)] + neg_evidence[(v, u)]
+                           for (u, v) in internal]
+                ig_g = igraph.Graph(n=len(cls_list), edges=local_edges,
+                                    directed=True)
+                ig_g.es['weight'] = weights
+                # Exact ILP — fast at our scale (<= 7 classes per SCC).
+                fas_local = ig_g.feedback_arc_set(weights='weight',
+                                                  method='exact_ip')
+                for li in fas_local:
+                    dropped_edges.add(internal[li])
+                    weight_dropped += weights[li]
+    else:
+        # Class-index fallback: deterministic within-SCC ordering.
+        within_qscc_pos = {}
+        for members in qscc_members.values():
+            for pos, cls in enumerate(sorted(members)):
+                within_qscc_pos[cls] = pos
+        for (u, v) in Q.edges():
+            if class_qscc[u] != class_qscc[v]:
+                continue  # different SCCs -> already forward
+            if within_qscc_pos[u] >= within_qscc_pos[v]:
+                dropped_edges.add((u, v))
+
     n_dropped = len(dropped_edges)
 
-    # Per-graph emission: same forward filter applied to each graph's
-    # cross-class arrows.
+    # Per-graph emission: drop any cross-class arrow whose quotient edge
+    # is in the dropped set; emit the rest.
     triples_seen = set()
     triples = []
     for g_idx, g in enumerate(glist):
@@ -935,21 +1034,16 @@ def _acyclic_quotient_edges(glist, partition):
                 kv = node_to_class.get(v)
                 if kv is None or ku == kv:
                     continue
-                if class_qscc[ku] != class_qscc[kv]:
-                    # Different quotient-SCCs -> direction is fixed by the
-                    # condensation (always forward).
-                    keep = True
-                else:
-                    keep = within_qscc_pos[ku] < within_qscc_pos[kv]
-                if keep:
-                    key = (ku, kv, g_idx + 1)
-                    if key not in triples_seen:
-                        triples_seen.add(key)
-                        triples.append(key)
-    return triples, n_dropped
+                if (ku, kv) in dropped_edges:
+                    continue
+                key = (ku, kv, g_idx + 1)
+                if key not in triples_seen:
+                    triples_seen.add(key)
+                    triples.append(key)
+    return triples, n_dropped, weight_dropped
 
 
-def encode_list_sccs(glist, scc_members=None):
+def encode_list_sccs(glist, scc_members=None, dm=None):
     """
     Encodes strongly connected components of a list of ``gunfolds`` graphs to
     ``clingo`` predicates and the three integrity constraints that use them.
@@ -1004,12 +1098,18 @@ def encode_list_sccs(glist, scc_members=None):
         # may technically reject some valid causal graphs whose cross-class
         # arrows go in dropped directions; in exchange the SCC integrity
         # constraints retain pruning power and per-SCC decomposition is
-        # meaningful.  See ``_acyclic_quotient_edges`` for the algorithm.
-        triples, n_dropped = _acyclic_quotient_edges(glist, SCCS)
+        # meaningful.  See ``_acyclic_quotient_edges`` for the algorithm —
+        # weighted MFAS via igraph when ``dm`` is provided, class-index
+        # fallback otherwise.
+        triples, n_dropped, weight_dropped = _acyclic_quotient_edges(
+            glist, SCCS, dm=dm)
         if n_dropped > 0:
+            method = "weighted MFAS" if dm is not None else "class-index"
+            extra = (f", total evidence cost: {weight_dropped}"
+                     if dm is not None else "")
             print(f"  [encode_list_sccs] supplied partition had a cyclic "
                   f"quotient; kept all {len(SCCS)} classes and dropped "
-                  f"{n_dropped} back-edge(s) to break cycles.")
+                  f"{n_dropped} back-edge(s) via {method}{extra}.")
         # Bucket triples by graph idx for per-graph emission.
         edges_by_idx = {}
         for (k, l, gi) in triples:

--- a/gunfolds/conversions.py
+++ b/gunfolds/conversions.py
@@ -744,33 +744,70 @@ def old_g2clingo(g, file=sys.stdout):
                 print('edgeu('+str(v)+','+str(w)+').', file=file)
                 print('confu('+str(v)+','+str(w)+').', file=file)
 
-def encode_sccs(g, idx, components=True, SCCS=None):
+def encode_sccs(g, idx, components=True, SCCS=None, quotient_edges=None):
     """
-    Encodes strongly connected components of ``gunfolds`` graph to ``clingo`` predicates 
+    Encodes strongly connected components of ``gunfolds`` graph to ``clingo`` predicates.
+
+    Emits three families of facts:
+
+    - ``scc_edge(K, L, idx)`` — there is at least one edge from a node in
+      group ``K`` to a node in group ``L`` in the measured graph ``g``.  This
+      is the edge relation of the quotient graph ``G / SCCS``.
+    - ``scc(node, K)`` — node membership in group ``K`` (only when
+      ``components=True``).
+    - ``sccsize(K, Z)`` — group ``K`` has ``Z`` nodes (only when
+      ``components=True``).
+
+    .. note::
+
+       The caller is responsible for passing a partition whose quotient is
+       acyclic, OR providing the ``quotient_edges`` override.  Callers that
+       go through :func:`encode_list_sccs` get this for free — that function
+       computes an acyclic edge set via :func:`_acyclic_quotient_edges`
+       (dropping back-edges within any cyclic SCC of the quotient) and
+       passes the result via ``quotient_edges``, so the partition itself is
+       preserved.
+
+       Direct callers who omit ``quotient_edges`` and pass an arbitrary
+       partition through ``SCCS`` will produce a cyclic ``scc_edge``
+       relation via NetworkX's :func:`condensation`, which makes the SCC
+       integrity constraints in :func:`encode_list_sccs` unsound.  Either
+       supply ``quotient_edges`` or pass ``SCCS=None`` to use the true SCCs
+       of ``g``.
+
+    :param quotient_edges: optional precomputed list of ``(K, L)`` quotient
+        edges to emit as ``scc_edge(K, L, idx)``.  When ``None``, the edge
+        set is computed via :func:`condensation` (which may produce cycles
+        for arbitrary partitions — see the note above).
+    :type quotient_edges: list of (int, int) pairs, or None
 
     :param g: ``gunfolds`` graph
     :type g: dictionary (``gunfolds`` graphs)
-    
+
     :param idx: index of the graph
     :type idx: integer
-    
+
     :param components: If True, encodes SCC components and memberships to ``clingo`` predicates
     :type components: boolean
-    
-    :param SCCS: SCC membership of nodes 
+
+    :param SCCS: SCC membership of nodes (or any node partition)
     :type SCCS: list
-    
-    :returns: ``clingo`` predicates 
+
+    :returns: ``clingo`` predicates
     :rtype: string
     """
     G = graph2nx(g)
     if SCCS is None:
         SCCS = strongly_connected_components(G)
-    CG = condensation(G, scc=SCCS)
     s = ''
-    for v in CG:
-        for w in CG[v]:
-            s += 'dag(' + str(v) + ', ' + str(w) + ', ' + str(idx) + '). '
+    if quotient_edges is not None:
+        for (v, w) in quotient_edges:
+            s += 'scc_edge(' + str(v) + ', ' + str(w) + ', ' + str(idx) + '). '
+    else:
+        CG = condensation(G, scc=SCCS)
+        for v in CG:
+            for w in CG[v]:
+                s += 'scc_edge(' + str(v) + ', ' + str(w) + ', ' + str(idx) + '). '
     if not components:
         return s
     for c, component in enumerate(SCCS):
@@ -785,37 +822,224 @@ def encode_sccs(g, idx, components=True, SCCS=None):
     return s
 
 
+def _acyclic_quotient_edges(glist, partition):
+    """
+    Compute the per-graph quotient edges for ``partition`` over ``glist``,
+    with cycles broken to keep the ``scc_edge/3`` relation acyclic *without*
+    merging any classes.
+
+    Why we drop edges instead of merging classes
+    --------------------------------------------
+    The DRASL encoding's SCC integrity constraints are technically sound
+    only when ``partition`` is a coarsening of the measured graph's actual
+    SCC partition (so the quotient is a DAG by construction).  When the
+    caller supplies a partition that *splits* a real SCC across multiple
+    classes — e.g. ``--scc_strategy=domain`` grouping by NeuroMark domain,
+    where two domains routinely exchange signals in both directions — the
+    quotient gains cycles.  The mathematically clean response is to merge
+    any classes within the same quotient-SCC; the side-effect on fMRI is
+    that *every* domain pair has bidirectional evidence at PCMCI
+    alpha=0.05, so the partition collapses to a single SCC and all SCC
+    pruning is lost.
+
+    This helper takes the *opposite* trade-off: keep every input class as
+    its own SCC in the encoding, and drop only the back-edges in the
+    quotient that close cycles.  The resulting ``scc_edge/3`` relation is
+    acyclic, the constraints fire on every cross-class arrow, and per-SCC
+    decomposition (e.g. solving each class as an independent sub-problem)
+    remains meaningful.
+
+    The cost is *technical unsoundness*: a valid causal graph whose
+    cross-class arrows happen to go in a dropped (back) direction will be
+    rejected.  This is an explicit speed-vs-correctness lever.
+
+    Algorithm
+    ---------
+    1. Build the union digraph ``H`` over ``glist`` (directed edges only;
+       bidirected edges do not contribute to the quotient).
+    2. Build the quotient ``Q`` over ``H`` using ``partition``.
+    3. Find SCCs of ``Q``.  Edges between distinct SCCs of ``Q`` are
+       always one-directional (otherwise the two SCCs would be a single
+       SCC), so they are kept verbatim.  Edges within a non-trivial SCC
+       of ``Q`` are filtered: we pick a deterministic within-SCC class
+       order (sorted by class index) and keep only forward edges.
+    4. Apply the same per-class forward filter to each graph in
+       ``glist`` independently to produce the final ``(K, L, idx)``
+       triples.
+
+    :param glist: list of measured graphs (gunfolds 1-indexed dicts).
+    :param partition: list of node-id sets — one per class.
+
+    :returns: a tuple ``(triples, n_dropped)``:
+        ``triples`` is a deduplicated list of ``(K, L, idx)`` triples to
+        emit as ``scc_edge`` facts (idx is 1-based);
+        ``n_dropped`` is the number of distinct ``(K, L)`` quotient edges
+        that were dropped to break cycles (0 means the partition's
+        quotient was already a DAG).
+    """
+    H = nx.DiGraph()
+    for g in glist:
+        for u in g:
+            H.add_node(u)
+            for v in g[u]:
+                # gunfolds edge codes: 1=directed, 2=bidirected, 3=both.
+                if g[u][v] in (1, 3):
+                    H.add_edge(u, v)
+
+    node_to_class = {}
+    for idx, members in enumerate(partition):
+        for n in members:
+            node_to_class[n] = idx
+
+    # Quotient over the union — used to detect within-SCC back-edges.
+    Q = nx.DiGraph()
+    Q.add_nodes_from(range(len(partition)))
+    for u, v in H.edges():
+        ku = node_to_class.get(u)
+        kv = node_to_class.get(v)
+        if ku is None or kv is None or ku == kv:
+            continue
+        Q.add_edge(ku, kv)
+
+    # For each non-trivial SCC of Q, fix a within-SCC order so that we
+    # can drop back-edges deterministically.  Singleton SCCs of Q play no
+    # role (no internal back-edges possible).
+    class_qscc = {}
+    within_qscc_pos = {}
+    for q_idx, comp in enumerate(strongly_connected_components(Q)):
+        for pos, cls in enumerate(sorted(comp)):
+            class_qscc[cls] = q_idx
+            within_qscc_pos[cls] = pos
+
+    # Count dropped quotient edges (distinct (K, L) pairs over the union).
+    union_edges = set(Q.edges())
+    dropped_edges = {
+        (u, v) for (u, v) in union_edges
+        if class_qscc[u] == class_qscc[v]
+        and within_qscc_pos[u] >= within_qscc_pos[v]
+    }
+    n_dropped = len(dropped_edges)
+
+    # Per-graph emission: same forward filter applied to each graph's
+    # cross-class arrows.
+    triples_seen = set()
+    triples = []
+    for g_idx, g in enumerate(glist):
+        for u in g:
+            ku = node_to_class.get(u)
+            if ku is None:
+                continue
+            for v in g[u]:
+                if g[u][v] not in (1, 3):
+                    continue
+                kv = node_to_class.get(v)
+                if kv is None or ku == kv:
+                    continue
+                if class_qscc[ku] != class_qscc[kv]:
+                    # Different quotient-SCCs -> direction is fixed by the
+                    # condensation (always forward).
+                    keep = True
+                else:
+                    keep = within_qscc_pos[ku] < within_qscc_pos[kv]
+                if keep:
+                    key = (ku, kv, g_idx + 1)
+                    if key not in triples_seen:
+                        triples_seen.add(key)
+                        triples.append(key)
+    return triples, n_dropped
+
+
 def encode_list_sccs(glist, scc_members=None):
     """
-    Encodes strongly connected components of a list of ``gunfolds`` graph to ``clingo`` predicates 
+    Encodes strongly connected components of a list of ``gunfolds`` graphs to
+    ``clingo`` predicates and the three integrity constraints that use them.
 
-    :param glist: a list of graphs that are under sampled versions of
+    Predicates emitted (per graph in ``glist``):
+
+    - ``scc_edge(K, L, idx)`` — the measured graph ``idx`` has at least one
+      edge from a node in group ``K`` to a node in group ``L``.  Always
+      acyclic across all idx values.  When ``scc_members`` is supplied and
+      its quotient would be cyclic, the cycle-creating back-edges are
+      dropped via :func:`_acyclic_quotient_edges` — every input class is
+      preserved as its own SCC in the encoding, but the constraint may
+      reject some valid causal graphs whose arrows go in dropped
+      directions.  This is an explicit speed-vs-soundness trade-off: it
+      keeps the per-class pruning power that lets the SCC integrity
+      constraints below actually fire, at the cost of technical
+      unsoundness.  The alternative (merging classes within each cyclic
+      quotient-SCC) is theoretically sounder but collapses the partition
+      to one class on typical fMRI data, eliminating all pruning.
+    - ``scc(node, K)``, ``sccsize(K, Z)`` — emitted only for the first graph
+      (the partition is graph-independent).
+
+    Constraints emitted:
+
+    1. No ``edge1(X, Y)`` may cross from group ``K`` to a non-singleton group
+       ``L`` unless the measured graph witnessed at least one direct quotient
+       edge ``K -> L`` (in any idx).
+    2. No ``2``-cycle between two distinct groups at the same undersampling
+       rate (would imply they are a single SCC).
+    3. Per-undersampling version of constraint (1): a ``U``-step directed
+       path crossing into a non-singleton group must be witnessed at the
+       matching ``u(U, idx)`` in the corresponding measured graph.
+
+    :param glist: a list of graphs that are under-sampled versions of
         the same system
     :type glist: list of dictionaries (``gunfolds`` graphs)
 
-    :param scc_members: a list of dictionaries for nodes in each SCC
-    :type scc_members: list
-    
-    :returns: ``clingo`` predicates 
+    :param scc_members: a list of node-id sets describing the SCC partition
+        used to interpret ``glist``.  If ``None``, the actual strongly
+        connected components of ``glist[0]`` are computed and used.
+    :type scc_members: list of sets, or None
+
+    :returns: ``clingo`` predicates
     :rtype: string
     """
     s = ''
+    if scc_members is not None:
+        SCCS = scc_members
+        # Precompute the acyclic quotient edge set: drop back-edges in any
+        # cyclic SCC of the quotient, but keep every input class as its own
+        # SCC in the encoding (no class merging).  Trade-off: the encoding
+        # may technically reject some valid causal graphs whose cross-class
+        # arrows go in dropped directions; in exchange the SCC integrity
+        # constraints retain pruning power and per-SCC decomposition is
+        # meaningful.  See ``_acyclic_quotient_edges`` for the algorithm.
+        triples, n_dropped = _acyclic_quotient_edges(glist, SCCS)
+        if n_dropped > 0:
+            print(f"  [encode_list_sccs] supplied partition had a cyclic "
+                  f"quotient; kept all {len(SCCS)} classes and dropped "
+                  f"{n_dropped} back-edge(s) to break cycles.")
+        # Bucket triples by graph idx for per-graph emission.
+        edges_by_idx = {}
+        for (k, l, gi) in triples:
+            edges_by_idx.setdefault(gi, []).append((k, l))
+    else:
+        SCCS = None  # will be computed from glist[0] inside encode_sccs
+        edges_by_idx = None  # condensation path inside encode_sccs
+
     first_graph = True
     for i, g in enumerate(glist):
-        if first_graph:
-            if scc_members is not None:
-                SCCS = scc_members
-            else:
-                SCCS = [s for s in strongly_connected_components(graph2nx(g))]
-        s += encode_sccs(g, i+1, components=first_graph, SCCS=SCCS)
+        if first_graph and SCCS is None:
+            SCCS = [c for c in strongly_connected_components(graph2nx(g))]
+        qe = (edges_by_idx.get(i + 1, []) if edges_by_idx is not None else None)
+        s += encode_sccs(g, i + 1, components=first_graph, SCCS=SCCS,
+                         quotient_edges=qe)
         first_graph = False
-    # if the generating graph has an edge between non singleton SCCs that are
-    # not connected in any of the measured graphs - no go
-    s += ':- edge1(X,Y), scc(X,K), scc(Y,L), K != L, sccsize(L,Z), Z > 1, not dag(K,L,_). '
-    # if the produced graph has a cycle connecting 2 SCCs - no go
+    # If the generating (causal-scale) graph proposes a cross-group edge to a
+    # non-singleton group L that was *never observed* in any measured graph
+    # (i.e. no scc_edge(K,L,_) fact for any graph idx), reject. ``scc_edge``
+    # here is the existence relation on quotient edges of the measured graph
+    # — it is not required to be a DAG; see ``encode_sccs`` for the rationale.
+    s += ':- edge1(X,Y), scc(X,K), scc(Y,L), K != L, sccsize(L,Z), Z > 1, not scc_edge(K,L,_). '
+    # If the produced graph has a 2-cycle between two distinct groups at the
+    # measurement undersampling rate, reject (would imply a single SCC).
     s += ':- directed(X,Y,M), directed(Y,X,N), scc(X, K), scc(Y,L), K != L, M<=U, N<=U, M<=N, u(U,_).'
-    # if there is an edge between SCCs in the produced graph and none in the measured for nonsingleton SCCs - no go
-    s += ':- directed(X,Y,U), scc(X,K), scc(Y,L), K != L, sccsize(L,Z), Z > 1, not dag(K,L,N), u(U,N).'
+    # Same check as the first constraint but at the per-undersampling level:
+    # forbid a U-step directed path crossing into a non-singleton group L
+    # unless the corresponding measured graph (idx N) directly witnessed a
+    # K -> L quotient edge.
+    s += ':- directed(X,Y,U), scc(X,K), scc(Y,L), K != L, sccsize(L,Z), Z > 1, not scc_edge(K,L,N), u(U,N).'
     return s
 
 

--- a/gunfolds/scripts/experiments/aggregate_pcmci_sweep.py
+++ b/gunfolds/scripts/experiments/aggregate_pcmci_sweep.py
@@ -1,0 +1,125 @@
+"""
+Aggregate pcmci_alpha_sweep.py outputs and pick the best alpha.
+
+Score (per Exp 4, fmri_experiment_large.py):
+    composite = 0.6 * median(cross-subject Jaccard) + 0.4 * density_proximity
+
+where:
+    density_proximity = max(0, 1 - |median_density - target_density| / target_density)
+
+Target density per N matches DEFAULT_GT_DENSITY_BY_N in fmri_experiment_large.py
+(divided by 100 to get a 0–1 fraction):
+    N=10 → 0.35
+    N=20 → 0.22
+    N=53 → 0.13
+
+Usage:
+    python aggregate_pcmci_sweep.py --input_dir results/pcmci_alpha_sweep_N53 \\
+        --n_components 53
+"""
+
+import argparse
+import glob
+import json
+import os
+from itertools import combinations
+
+import numpy as np
+
+
+TARGET_DENSITY = {10: 0.35, 20: 0.22, 53: 0.13}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input_dir", required=True,
+                   help="Directory containing alpha_*.json files")
+    p.add_argument("--n_components", type=int, required=True,
+                   choices=[10, 20, 53])
+    p.add_argument("--max_pairs", type=int, default=10000,
+                   help="Cap on Jaccard pairs (full N=311 → 48k pairs; sample if larger)")
+    p.add_argument("--output_csv", type=str, default=None,
+                   help="Optional path to write a CSV summary")
+    return p.parse_args()
+
+
+def jaccard(a_edges, b_edges):
+    A = set(map(tuple, a_edges))
+    B = set(map(tuple, b_edges))
+    if not A and not B:
+        return 1.0
+    return len(A & B) / len(A | B)
+
+
+def score_one_file(path, max_pairs):
+    with open(path) as f:
+        d = json.load(f)
+    rows = [r for r in d["rows"] if "edges" in r]   # drop failures
+    if len(rows) < 2:
+        return None
+    densities = np.array([r["density"] for r in rows])
+    pairs = list(combinations(range(len(rows)), 2))
+    if len(pairs) > max_pairs:
+        rng = np.random.default_rng(0)
+        idx = rng.choice(len(pairs), size=max_pairs, replace=False)
+        pairs = [pairs[i] for i in idx]
+    jaccs = [jaccard(rows[i]["edges"], rows[j]["edges"]) for i, j in pairs]
+    return {
+        "alpha": d["meta"]["alpha"],
+        "n_subjects": len(rows),
+        "n_failures": d["meta"]["n_failures"],
+        "median_density": float(np.median(densities)),
+        "iqr_density": float(np.percentile(densities, 75) - np.percentile(densities, 25)),
+        "median_jaccard": float(np.median(jaccs)),
+        "median_n_edges": float(np.median([r["n_edges"] for r in rows])),
+        "total_time_sec": d["meta"]["total_time_sec"],
+    }
+
+
+def main():
+    args = parse_args()
+    target = TARGET_DENSITY[args.n_components]
+    paths = sorted(glob.glob(os.path.join(args.input_dir, "alpha_*.json")))
+    if not paths:
+        raise SystemExit(f"No alpha_*.json files in {args.input_dir}")
+
+    results = []
+    for p in paths:
+        r = score_one_file(p, args.max_pairs)
+        if r is None:
+            print(f"  [skip] {os.path.basename(p)} — fewer than 2 successful subjects")
+            continue
+        r["target_density"] = target
+        r["density_proximity"] = max(
+            0.0, 1.0 - abs(r["median_density"] - target) / target
+        )
+        r["composite"] = 0.6 * r["median_jaccard"] + 0.4 * r["density_proximity"]
+        results.append(r)
+
+    results.sort(key=lambda r: -r["composite"])
+
+    hdr = f"{'alpha':>7}  {'jacc':>5}  {'dens':>5}  {'prox':>5}  {'compos':>6}  {'edges':>5}  {'fails':>5}  {'time(s)':>7}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in results:
+        print(f"{r['alpha']:>7.4f}  {r['median_jaccard']:>5.3f}  "
+              f"{r['median_density']:>5.3f}  {r['density_proximity']:>5.3f}  "
+              f"{r['composite']:>6.3f}  {r['median_n_edges']:>5.0f}  "
+              f"{r['n_failures']:>5d}  {r['total_time_sec']:>7.0f}")
+    print()
+    best = results[0]
+    print(f"BEST: alpha={best['alpha']}  composite={best['composite']:.3f}  "
+          f"(N={args.n_components}, target_density={target})")
+
+    if args.output_csv:
+        import csv
+        with open(args.output_csv, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(results[0].keys()))
+            w.writeheader()
+            for r in results:
+                w.writerow(r)
+        print(f"wrote: {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gunfolds/scripts/experiments/aggregate_results.py
+++ b/gunfolds/scripts/experiments/aggregate_results.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 
 
-N_VALUES = [8, 10, 12, 14, 18, 20]
+N_VALUES = [8, 10, 12, 14, 18, 20, 24, 30, 42, 54]
 INSTANCES_PER_N = 10
 
 

--- a/gunfolds/scripts/experiments/aggregate_results.py
+++ b/gunfolds/scripts/experiments/aggregate_results.py
@@ -1,0 +1,145 @@
+"""
+Aggregate per-instance CSVs from the runtime-scaling experiment and print
+the headline "N → solve time" table.
+
+Reads:   <input_dir>/n*_inst*.csv  (one row each)
+Writes:  <input_dir>/runtime_scaling_master.csv
+Prints:  the headline table (median + IQR + completion rate per N)
+
+Usage:
+    python aggregate_results.py --input_dir results/runtime_scaling/
+    python aggregate_results.py --input_dir results/runtime_scaling/ --plot
+"""
+
+import argparse
+import glob
+import os
+
+import numpy as np
+import pandas as pd
+
+
+N_VALUES = [8, 10, 12, 14, 18, 20]
+INSTANCES_PER_N = 10
+
+
+def fmt_time(seconds):
+    """Human-readable: s for ≤60, m for 60-3600, h for >3600."""
+    if seconds is None or (isinstance(seconds, float) and np.isnan(seconds)):
+        return "  --   "
+    if seconds <= 60:
+        return f"{seconds:6.2f}s"
+    if seconds <= 3600:
+        return f"{seconds / 60:6.2f}m"
+    return f"{seconds / 3600:6.2f}h"
+
+
+def fmt_iqr(lo, hi):
+    if lo is None or np.isnan(lo) or hi is None or np.isnan(hi):
+        return "[  --   ,   --   ]"
+    return f"[{fmt_time(lo).strip()}, {fmt_time(hi).strip()}]"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input_dir", default="results/runtime_scaling/")
+    p.add_argument("--plot", action="store_true",
+                   help="Save runtime_scaling.svg with per-instance markers + "
+                        "median highlighted (log-y vs n_nodes).")
+    args = p.parse_args()
+
+    pattern = os.path.join(args.input_dir, "n*_inst*.csv")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(f"No files matching {pattern}")
+        return
+
+    frames = []
+    for f in files:
+        try:
+            frames.append(pd.read_csv(f))
+        except Exception as e:
+            print(f"  [WARN] could not read {f}: {e}")
+    if not frames:
+        print("No CSVs successfully read.")
+        return
+
+    master = pd.concat(frames, ignore_index=True)
+    master_path = os.path.join(args.input_dir, "runtime_scaling_master.csv")
+    master.to_csv(master_path, index=False)
+    print(f"Wrote {master_path}  ({len(master)} rows)\n")
+
+    # ── Headline table ───────────────────────────────────────────────────
+    header = (
+        f"{'n_nodes':>7s}  {'median(drasl_time_sec)':>22s}  "
+        f"{'IQR':>26s}  {'completion_rate':>17s}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    minmax_lines = []
+    for N in N_VALUES:
+        rows = master[master["n_nodes"] == N]
+        completed = rows[rows["status"] == "completed"]
+        total = len(rows) if len(rows) else INSTANCES_PER_N
+
+        if len(completed) == 0:
+            print(f"{N:>7d}  {'  --   ':>22s}  "
+                  f"{'[  --   ,   --   ]':>26s}  "
+                  f"{f'0/{total}':>17s}")
+            continue
+
+        times = completed["drasl_time_sec"].astype(float).dropna().values
+        med = float(np.median(times))
+        q1 = float(np.percentile(times, 25))
+        q3 = float(np.percentile(times, 75))
+        comp = f"{len(completed)}/{total}"
+
+        print(f"{N:>7d}  {fmt_time(med):>22s}  "
+              f"{fmt_iqr(q1, q3):>26s}  {comp:>17s}")
+
+        mn = float(np.min(times)); mx = float(np.max(times))
+        minmax_lines.append(
+            f"  N={N:>2d}  min={fmt_time(mn).strip():>9s}  "
+            f"max={fmt_time(mx).strip():>9s}  n_completed={len(completed)}"
+        )
+
+    if minmax_lines:
+        print("\nPer-N min/max:")
+        for line in minmax_lines:
+            print(line)
+
+    # ── Optional plot ────────────────────────────────────────────────────
+    if args.plot:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+        for N in N_VALUES:
+            rows = master[(master["n_nodes"] == N) & (master["status"] == "completed")]
+            times = rows["drasl_time_sec"].astype(float).dropna().values
+            if len(times) == 0:
+                continue
+            ax.scatter([N] * len(times), times, alpha=0.4, color="steelblue",
+                       s=30, label="instance" if N == N_VALUES[0] else None)
+            ax.scatter([N], [np.median(times)], marker="D", s=80,
+                       color="darkorange", edgecolor="black",
+                       label="median" if N == N_VALUES[0] else None,
+                       zorder=5)
+
+        ax.set_yscale("log")
+        ax.set_xlabel("n_nodes")
+        ax.set_ylabel("drasl_time_sec (log)")
+        ax.set_xticks(N_VALUES)
+        ax.set_title("drasl runtime vs n_nodes (per-instance + median)")
+        ax.grid(True, which="both", alpha=0.3)
+        ax.legend(loc="upper left")
+        plot_path = os.path.join(args.input_dir, "runtime_scaling.svg")
+        fig.tight_layout()
+        fig.savefig(plot_path, format="svg")
+        print(f"\nPlot: {plot_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gunfolds/scripts/experiments/check_status.sh
+++ b/gunfolds/scripts/experiments/check_status.sh
@@ -59,8 +59,27 @@ show_status() {
             local state="missing"
             local extra=""
 
-            # 1. Check the CSV first — final outcome wins.
-            if [ -f "$csv" ]; then
+            # 1. Live queue state wins over historical CSV.  If a job with this
+            #    name is currently queued/running, the CSV (if any) reflects an
+            #    earlier run that's about to be overwritten — so report the
+            #    in-flight state instead.
+            local sq_state
+            sq_state=$(echo "$squeue_snap" | awk -v n="$job_name" '$1==n {print $2; exit}')
+            if [ -n "$sq_state" ]; then
+                case "$sq_state" in
+                    R|RUNNING)        state="running"; extra="(in queue: RUNNING)" ;;
+                    PD|PENDING)       state="pending"; extra="(in queue: PENDING)" ;;
+                    CG|COMPLETING)    state="running"; extra="(in queue: COMPLETING)" ;;
+                    *)                state="running"; extra="(in queue: $sq_state)" ;;
+                esac
+                # Note if there's a historical CSV that will be overwritten.
+                if [ -f "$csv" ]; then
+                    local prev
+                    prev=$(tail -n 1 "$csv" 2>/dev/null | awk -F',' '{print $NF}' | cut -c1-30)
+                    extra="$extra  [prev: $prev]"
+                fi
+            elif [ -f "$csv" ]; then
+                # 2. No live job — CSV is authoritative.
                 local last
                 last=$(tail -n 1 "$csv" 2>/dev/null)
                 if echo "$last" | grep -q ',completed$'; then
@@ -74,25 +93,11 @@ show_status() {
                     state="error"
                     extra="(timeout)"
                 else
-                    # any other status string (error: ...)
                     state="error"
                     extra=$(echo "$last" | awk -F',' '{print $NF}' | cut -c1-60)
                 fi
             fi
-
-            # 2. If no CSV yet, check squeue.
-            if [ "$state" = "missing" ]; then
-                local sq_state
-                sq_state=$(echo "$squeue_snap" | awk -v n="$job_name" '$1==n {print $2; exit}')
-                if [ -n "$sq_state" ]; then
-                    case "$sq_state" in
-                        R|RUNNING)        state="running"; extra="(in queue: RUNNING)" ;;
-                        PD|PENDING)       state="pending"; extra="(in queue: PENDING)" ;;
-                        CG|COMPLETING)    state="running"; extra="(in queue: COMPLETING)" ;;
-                        *)                state="running"; extra="(in queue: $sq_state)" ;;
-                    esac
-                fi
-            fi
+            # 3. Else: state stays "missing" (no CSV and not in queue).
 
             # Tally.
             STATE_COUNT[$state]=$(( ${STATE_COUNT[$state]:-0} + 1 ))

--- a/gunfolds/scripts/experiments/check_status.sh
+++ b/gunfolds/scripts/experiments/check_status.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Status checker for the runtime_scaling experiment.
+#
+# Cross-references three sources:
+#   1. results/runtime_scaling/n{N}_inst{I}.csv  — completed/errored runs
+#   2. squeue -u $USER                            — currently queued/running
+#   3. nothing of the above                       — missing
+#
+# Usage:
+#   bash check_status.sh           # summary table
+#   bash check_status.sh --full    # also list every (N, inst) state
+#   bash check_status.sh --watch   # auto-refresh every 30s
+
+set -u
+
+OUTPUT_DIR="results/runtime_scaling"
+N_VALUES=(8 10 12 14 18 20 24 30 42 54)
+INSTANCES_PER_N=10
+
+FULL=0
+WATCH=0
+for arg in "$@"; do
+    case "$arg" in
+        --full)  FULL=1 ;;
+        --watch) WATCH=1 ;;
+    esac
+done
+
+show_status() {
+    # Snapshot the squeue once (cheap)
+    local squeue_snap
+    squeue_snap=$(squeue -u "$USER" -h -o "%j %T" 2>/dev/null || true)
+
+    declare -A STATE_COUNT
+    STATE_COUNT[completed]=0
+    STATE_COUNT[error]=0
+    STATE_COUNT[running]=0
+    STATE_COUNT[pending]=0
+    STATE_COUNT[missing]=0
+
+    declare -A PER_N_DONE
+    declare -A PER_N_ERR
+    declare -A PER_N_RUN
+    declare -A PER_N_PEND
+    declare -A PER_N_MISS
+
+    local detail=""
+
+    for N in "${N_VALUES[@]}"; do
+        PER_N_DONE[$N]=0
+        PER_N_ERR[$N]=0
+        PER_N_RUN[$N]=0
+        PER_N_PEND[$N]=0
+        PER_N_MISS[$N]=0
+
+        for ((I=0; I<INSTANCES_PER_N; I++)); do
+            local job_name="rt_n${N}_i${I}"
+            local csv="${OUTPUT_DIR}/n${N}_inst${I}.csv"
+            local state="missing"
+            local extra=""
+
+            # 1. Check the CSV first — final outcome wins.
+            if [ -f "$csv" ]; then
+                local last
+                last=$(tail -n 1 "$csv" 2>/dev/null)
+                if echo "$last" | grep -q ',completed$'; then
+                    state="completed"
+                    # Pull drasl_time and total_time from the row (cols 6 and 7).
+                    local drasl_time total_time
+                    drasl_time=$(echo "$last" | awk -F',' '{print $6}')
+                    total_time=$(echo "$last" | awk -F',' '{print $7}')
+                    extra="drasl=${drasl_time}s total=${total_time}s"
+                elif echo "$last" | grep -q ',timeout'; then
+                    state="error"
+                    extra="(timeout)"
+                else
+                    # any other status string (error: ...)
+                    state="error"
+                    extra=$(echo "$last" | awk -F',' '{print $NF}' | cut -c1-60)
+                fi
+            fi
+
+            # 2. If no CSV yet, check squeue.
+            if [ "$state" = "missing" ]; then
+                local sq_state
+                sq_state=$(echo "$squeue_snap" | awk -v n="$job_name" '$1==n {print $2; exit}')
+                if [ -n "$sq_state" ]; then
+                    case "$sq_state" in
+                        R|RUNNING)        state="running"; extra="(in queue: RUNNING)" ;;
+                        PD|PENDING)       state="pending"; extra="(in queue: PENDING)" ;;
+                        CG|COMPLETING)    state="running"; extra="(in queue: COMPLETING)" ;;
+                        *)                state="running"; extra="(in queue: $sq_state)" ;;
+                    esac
+                fi
+            fi
+
+            # Tally.
+            STATE_COUNT[$state]=$(( ${STATE_COUNT[$state]:-0} + 1 ))
+            case "$state" in
+                completed) PER_N_DONE[$N]=$(( ${PER_N_DONE[$N]} + 1 )) ;;
+                error)     PER_N_ERR[$N]=$(( ${PER_N_ERR[$N]} + 1 )) ;;
+                running)   PER_N_RUN[$N]=$(( ${PER_N_RUN[$N]} + 1 )) ;;
+                pending)   PER_N_PEND[$N]=$(( ${PER_N_PEND[$N]} + 1 )) ;;
+                missing)   PER_N_MISS[$N]=$(( ${PER_N_MISS[$N]} + 1 )) ;;
+            esac
+
+            if [ "$FULL" = "1" ]; then
+                local mark
+                case "$state" in
+                    completed) mark="✓ completed" ;;
+                    error)     mark="✗ error    " ;;
+                    running)   mark="▶ running  " ;;
+                    pending)   mark="⏳ pending  " ;;
+                    missing)   mark="? missing  " ;;
+                esac
+                detail+=$(printf "  N=%-2d inst=%d  %s  %s\n" "$N" "$I" "$mark" "$extra")
+                detail+=$'\n'
+            fi
+        done
+    done
+
+    # ─── Output ───────────────────────────────────────────────────────────
+    echo "=== runtime_scaling status @ $(date '+%Y-%m-%d %H:%M:%S') ==="
+    echo
+
+    # Per-N table
+    printf "  %-4s | %-9s | %-6s | %-7s | %-7s | %-7s\n" \
+        "N" "completed" "error" "running" "pending" "missing"
+    printf "  -----+-----------+--------+---------+---------+--------\n"
+    for N in "${N_VALUES[@]}"; do
+        printf "  %-4d | %-9s | %-6s | %-7s | %-7s | %-7s\n" \
+            "$N" \
+            "${PER_N_DONE[$N]}/$INSTANCES_PER_N" \
+            "${PER_N_ERR[$N]}" \
+            "${PER_N_RUN[$N]}" \
+            "${PER_N_PEND[$N]}" \
+            "${PER_N_MISS[$N]}"
+    done
+
+    # Grand total
+    local total=$(( INSTANCES_PER_N * ${#N_VALUES[@]} ))
+    echo
+    printf "  TOTAL: %d completed / %d  (errors=%d  running=%d  pending=%d  missing=%d)\n" \
+        "${STATE_COUNT[completed]}" "$total" \
+        "${STATE_COUNT[error]}" \
+        "${STATE_COUNT[running]}" \
+        "${STATE_COUNT[pending]}" \
+        "${STATE_COUNT[missing]}"
+
+    # Optional full per-instance detail
+    if [ "$FULL" = "1" ]; then
+        echo
+        echo "=== per-instance detail ==="
+        echo "$detail"
+    fi
+}
+
+if [ "$WATCH" = "1" ]; then
+    while true; do
+        clear
+        show_status
+        echo
+        echo "(refreshing every 30s — Ctrl-C to exit)"
+        sleep 30
+    done
+else
+    show_status
+fi

--- a/gunfolds/scripts/experiments/pcmci_alpha_sweep.py
+++ b/gunfolds/scripts/experiments/pcmci_alpha_sweep.py
@@ -1,0 +1,141 @@
+"""
+PCMCI-only alpha sweep — no drasl, no ground truth.
+
+One run = one alpha value over all subjects. Writes a JSON file with per-subject
+PCMCI graph density + edge list, suitable for the Exp 4 composite-score recipe
+(0.6 × cross-subject Jaccard + 0.4 × density proximity to N-specific target).
+
+Usage:
+    python pcmci_alpha_sweep.py --alpha 0.05 --n_components 53 \\
+        --data_path ../fbirn/fbirn_sz_data.npz \\
+        --output_dir results/pcmci_alpha_sweep_N53/
+
+Designed to be submitted as a SLURM array (one task per alpha).
+PCMCI at N=53 is ~10–60 s per subject, so 311 subjects ≈ 1–6 hours per alpha.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+
+import numpy as np
+
+# Make the repo importable when invoked as a script.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.join(_HERE, "..", "..", "..")
+sys.path.insert(0, _ROOT)
+
+from gunfolds.utils import graphkit as gk
+from gunfolds.scripts.real_data.component_config import get_comp_indices
+from gunfolds.scripts.real_data.fmri_experiment_large import (
+    run_pcmci_to_cg, get_labels,
+)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--alpha", type=float, required=True,
+                   help="PCMCI alpha (used for both alpha_level and pc_alpha)")
+    p.add_argument("--n_components", type=int, required=True,
+                   choices=[10, 20, 53])
+    p.add_argument("--data_path", type=str,
+                   default="../fbirn/fbirn_sz_data.npz")
+    p.add_argument("--output_dir", type=str,
+                   default="results/pcmci_alpha_sweep")
+    p.add_argument("--pcmci_method", type=str, default="pcmci",
+                   choices=["pcmci", "pcmciplus"])
+    p.add_argument("--tau_max", type=int, default=1)
+    p.add_argument("--fdr", type=str, default="none",
+                   choices=["none", "fdr_bh"])
+    p.add_argument("--subject_start", type=int, default=0,
+                   help="First subject index (inclusive)")
+    p.add_argument("--subject_end", type=int, default=-1,
+                   help="Last subject index (exclusive); -1 = all")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_path = os.path.join(args.output_dir, f"alpha_{args.alpha:.4f}.json")
+
+    print("=" * 70, flush=True)
+    print(f"pcmci_alpha_sweep — alpha={args.alpha}  N={args.n_components}",
+          flush=True)
+    print(f"  method={args.pcmci_method} tau_max={args.tau_max} fdr={args.fdr}",
+          flush=True)
+    print(f"  output: {out_path}", flush=True)
+    print(f"  start  {datetime.now()}", flush=True)
+    print("=" * 70, flush=True)
+
+    comp_indices = get_comp_indices(args.n_components)
+    npz = np.load(args.data_path)
+    data = npz["data"]
+    labels = get_labels(npz)
+    n_subj = data.shape[0]
+    end = n_subj if args.subject_end < 0 else min(n_subj, args.subject_end)
+
+    rows = []
+    fail_count = 0
+    overall_t0 = time.perf_counter()
+
+    for s in range(args.subject_start, end):
+        ts_2d = data[s][:, comp_indices]
+        t0 = time.perf_counter()
+        try:
+            g_est, _, _ = run_pcmci_to_cg(
+                ts_2d,
+                pcmci_method=args.pcmci_method,
+                tau_max=args.tau_max,
+                alpha_level=args.alpha,
+                pc_alpha=args.alpha,
+                fdr_method=args.fdr,
+            )
+            density = float(gk.density(g_est))
+            edges = [[int(i), int(j)] for i in g_est for j in g_est[i]]
+            rows.append({
+                "subject": int(s),
+                "group": int(labels[s]),
+                "density": density,
+                "n_edges": len(edges),
+                "edges": edges,
+                "pcmci_time_sec": round(time.perf_counter() - t0, 3),
+            })
+        except Exception as e:
+            fail_count += 1
+            rows.append({
+                "subject": int(s),
+                "group": int(labels[s]),
+                "error": f"{type(e).__name__}: {e}",
+                "pcmci_time_sec": round(time.perf_counter() - t0, 3),
+            })
+            print(f"  [s={s:03d}] FAILED: {type(e).__name__}: {e}", flush=True)
+
+        if (s + 1) % 25 == 0 or s == end - 1:
+            elapsed = time.perf_counter() - overall_t0
+            print(f"  progress: {s + 1 - args.subject_start}/{end - args.subject_start}  "
+                  f"elapsed={elapsed:.0f}s  fails={fail_count}", flush=True)
+
+    meta = {
+        "alpha": args.alpha,
+        "n_components": args.n_components,
+        "pcmci_method": args.pcmci_method,
+        "tau_max": args.tau_max,
+        "fdr": args.fdr,
+        "data_path": args.data_path,
+        "subject_range": [args.subject_start, end],
+        "n_subjects": end - args.subject_start,
+        "n_failures": fail_count,
+        "total_time_sec": round(time.perf_counter() - overall_t0, 2),
+        "timestamp": datetime.now().isoformat(),
+    }
+    with open(out_path, "w") as f:
+        json.dump({"meta": meta, "rows": rows}, f)
+    print(f"\nwrote {out_path}  ({meta['total_time_sec']:.0f}s total)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -95,6 +95,7 @@ NOISE = 0.1
 U_RATE = 2
 
 # SCC composition table (max SCC size = 6).  Documented in prompt.
+# Compositions for N >= 24 are uniform 6-node SCCs (N must be a multiple of 6).
 SCC_COMPOSITION = {
     8:  [6, 2],
     10: [6, 4],
@@ -102,6 +103,10 @@ SCC_COMPOSITION = {
     14: [6, 4, 4],
     18: [6, 6, 6],
     20: [6, 6, 4, 4],
+    24: [6] * 4,
+    30: [6] * 5,
+    42: [6] * 7,
+    54: [6] * 9,
 }
 
 

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -216,15 +216,46 @@ def verify_partition(g, partition, max_scc_size):
 # VAR + BOLD simulation — match exp4_pcmci_drasl_ringmore5.py
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _sample_W(A, scale_aware=True, bias_magnitudes=False):
+    # Idea 1: pre-scale draws so post-damping entries stay O(1).
+    #   ρ(random sparse) ~ σ·√(mean_in_degree); choose σ so ρ ≈ 1.
+    # Idea 2: bias away from zero so |W^n| stays above the floor for more n.
+    N = A.shape[0]
+    if scale_aware:
+        mean_in_deg = max(1.0, A.sum(axis=0).mean())
+        sigma = 1.0 / np.sqrt(mean_in_deg)
+    else:
+        sigma = 1.0
+    if bias_magnitudes:
+        r = np.random.randn(*A.shape)
+        # |entry| in [0.5σ, ~2.5σ], sign uniform
+        mag = sigma * (0.5 + 0.5 * np.abs(r))
+        W = A * np.sign(r) * mag
+    else:
+        W = A * (sigma * np.random.randn(*A.shape))
+    return W
+
+
 def create_stable_weighted_matrix(A, threshold=0.1, powers=(1, 2, 3, 4),
-                                  max_attempts=1_000_000, damping=0.99):
-    # NOTE: exp4_pcmci_drasl_ringmore5.py used `scipy.sparse.linalg.eigs(Ws, k=1)`
-    # here (Arnoldi/ARPACK iterative method).  For N >= ~50 this routinely
-    # fails to converge on random W ("ARPACK error -1: No convergence"),
-    # killing the job before drasl runs.  Dense `np.linalg.eigvals` is fast
-    # and robust at our sizes (N <= 54), so we use it instead.
+                                  max_attempts=1_000_000, damping=0.99,
+                                  scale_aware=True, bias_magnitudes=False,
+                                  auto_threshold=False,
+                                  threshold_decay_ref_n=8):
+    # NOTE: exp4_pcmci_drasl_ringmore5.py used scipy.sparse.linalg.eigs (ARPACK)
+    # which routinely fails to converge for N>=50.  Dense np.linalg.eigvals is
+    # fast and robust at N<=54.
+    #
+    # Ideas implemented:
+    #   1) scale_aware     — σ = 1/√⟨in-deg⟩ keeps ρ(W) near 1 before damping
+    #   2) bias_magnitudes — draw |entry| ≥ 0.5σ so powers stay above floor
+    #   3) auto_threshold  — threshold scales by √(ref_N/N); set threshold=base
+    #   4) powers          — caller picks lag set; () disables filter entirely
+    N = A.shape[0]
+    if auto_threshold and N > threshold_decay_ref_n:
+        threshold = threshold * np.sqrt(threshold_decay_ref_n / N)
+
     for _ in range(max_attempts):
-        W = A * np.random.randn(*A.shape)
+        W = _sample_W(A, scale_aware=scale_aware, bias_magnitudes=bias_magnitudes)
         evals = np.linalg.eigvals(W)
         rho = np.abs(evals).max()
         if rho == 0:
@@ -240,6 +271,96 @@ def create_stable_weighted_matrix(A, threshold=0.1, powers=(1, 2, 3, 4),
         if ok:
             return W
     raise ValueError(f'Could not find stable matrix after {max_attempts} tries.')
+
+
+def construct_stable_matrix_from_sccs(A, partition, spectral_radius=0.95,
+                                       min_magnitude=0.2, max_magnitude=0.8):
+    # Idea 5: deterministic block-triangular construction.
+    #   - Per SCC: place eigenvalues on a circle of radius `spectral_radius`
+    #     by building a normalised companion-style block, then mask by the
+    #     SCC's own adjacency pattern with sampled magnitudes ≥ min_magnitude.
+    #   - Cross-SCC edges: sampled in [min_magnitude, max_magnitude] with
+    #     random sign.  Quotient is a DAG so cross-edges don't affect ρ(W).
+    # Returns a W with sparsity ⊆ A, ρ(W) ≤ spectral_radius by construction,
+    # and every nonzero entry ≥ min_magnitude in magnitude.
+    N = A.shape[0]
+    W = np.zeros_like(A, dtype=float)
+
+    # node-id (1-indexed from partition) → matrix index (0-indexed)
+    # partition is 1-indexed per make_multi_scc_ring convention
+    node_to_idx = {}
+    for scc in partition:
+        for node in scc:
+            node_to_idx[node] = node - 1  # gunfolds 1-indexed → 0-indexed
+
+    def _rand_mag():
+        return np.random.uniform(min_magnitude, max_magnitude)
+
+    def _rand_signed():
+        return _rand_mag() * np.random.choice([-1.0, 1.0])
+
+    for scc in partition:
+        idxs = [node_to_idx[n] for n in scc]
+        k = len(idxs)
+        if k == 1:
+            i = idxs[0]
+            if A[i, i] != 0:
+                W[i, i] = spectral_radius * np.random.choice([-1.0, 1.0])
+            continue
+
+        # Sub-block: build a magnitudes matrix only where A has edges.
+        sub = np.zeros((k, k))
+        for a, ia in enumerate(idxs):
+            for b, ib in enumerate(idxs):
+                if A[ia, ib] != 0:
+                    sub[a, b] = _rand_signed()
+        # Rescale this block to target spectral radius.
+        evals = np.linalg.eigvals(sub)
+        rho = np.abs(evals).max()
+        if rho > 0:
+            sub *= spectral_radius / rho
+        # Floor magnitudes: any nonzero that fell below min_magnitude gets
+        # bumped back up (preserves sign).  Slightly perturbs ρ but keeps
+        # it below spectral_radius * (max_magnitude/min_magnitude) bound.
+        nz = sub != 0
+        small = nz & (np.abs(sub) < min_magnitude)
+        if small.any():
+            sub[small] = np.sign(sub[small]) * min_magnitude
+        for a, ia in enumerate(idxs):
+            for b, ib in enumerate(idxs):
+                W[ia, ib] = sub[a, b]
+
+    # Cross-SCC edges: any A[i,j] not yet filled and not on the diagonal of
+    # the SCC blocks above.
+    scc_node_sets = [set(node_to_idx[n] for n in scc) for scc in partition]
+
+    def _same_scc(i, j):
+        for s in scc_node_sets:
+            if i in s and j in s:
+                return True
+        return False
+
+    nz_a = np.argwhere(A != 0)
+    for i, j in nz_a:
+        if _same_scc(i, j):
+            continue
+        W[i, j] = _rand_signed()
+
+    return W
+
+
+def get_stable_weighted_matrix(A, partition=None, strategy='sample', **kwargs):
+    if strategy == 'construct':
+        if partition is None:
+            raise ValueError("strategy='construct' requires partition")
+        return construct_stable_matrix_from_sccs(
+            A, partition,
+            spectral_radius=kwargs.get('damping', 0.95),
+            min_magnitude=kwargs.get('threshold', 0.2),
+        )
+    if strategy != 'sample':
+        raise ValueError(f"unknown strategy {strategy!r}")
+    return create_stable_weighted_matrix(A, **kwargs)
 
 
 def simulate_var(W, ssize, noise):
@@ -451,6 +572,27 @@ def main():
     parser.add_argument("--ssize", type=int, default=SSIZE)
     parser.add_argument("--noise", type=float, default=NOISE)
     parser.add_argument("--u_rate", type=int, default=U_RATE)
+    # Stable-matrix strategy (ideas 1–5).  Defaults preserve old behaviour
+    # (no path-strength filter); flags let you re-enable a calibrated filter
+    # or switch to deterministic block-triangular construction at high N.
+    parser.add_argument("--w_strategy", choices=['sample', 'construct'],
+                        default='sample',
+                        help="'sample': random + rejection (ideas 1-4); "
+                             "'construct': deterministic block-triangular "
+                             "from SCC partition (idea 5).")
+    parser.add_argument("--w_threshold", type=float, default=0.0,
+                        help="Path-strength floor.  0 disables filter.")
+    parser.add_argument("--w_powers", type=str, default="",
+                        help="Comma-sep lag powers to check, e.g. '1,2'. "
+                             "Empty disables filter (default).")
+    parser.add_argument("--w_scale_aware", action='store_true', default=True,
+                        help="Idea 1: σ = 1/√⟨in-deg⟩.  On by default.")
+    parser.add_argument("--w_no_scale_aware", dest='w_scale_aware',
+                        action='store_false')
+    parser.add_argument("--w_bias_magnitudes", action='store_true', default=False,
+                        help="Idea 2: bias |entry| away from zero.")
+    parser.add_argument("--w_auto_threshold", action='store_true', default=False,
+                        help="Idea 3: scale threshold by √(8/N).")
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)
@@ -520,7 +662,18 @@ def main():
         # determined by spectral radius < 1, which is enforced by the
         # damping/rho normalisation inside create_stable_weighted_matrix —
         # no extra filter is needed.
-        W = create_stable_weighted_matrix(A, threshold=0.0, powers=())
+        powers_tuple = tuple(int(p) for p in args.w_powers.split(',')
+                             if p.strip()) if args.w_powers else ()
+        W = get_stable_weighted_matrix(
+            A,
+            partition=partition,
+            strategy=args.w_strategy,
+            threshold=args.w_threshold,
+            powers=powers_tuple,
+            scale_aware=args.w_scale_aware,
+            bias_magnitudes=args.w_bias_magnitudes,
+            auto_threshold=args.w_auto_threshold,
+        )
         var_data = simulate_var(W, ssize=args.ssize * args.u_rate,
                                 noise=args.noise)
         bold_data = simulate_bold(var_data, u_rate=args.u_rate)

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -1,0 +1,582 @@
+"""
+Runtime scaling experiment for drasl on SCC-ring synthetic graphs.
+
+One job per (n_nodes, instance_id).  Pipeline:
+  1. Deterministic seed from (n_nodes, instance_id)
+  2. Ground-truth multi-SCC ring graph G^1 (max SCC size = 6)
+  3. VAR + balloon-BOLD simulation (mirroring exp4_pcmci_drasl_ringmore5.py)
+  4. PCMCI on BOLD                       (mirroring benchmark_domain_heuristic.py)
+  5. drasl via drasl_command + clingo.Control with threading.Timer interrupt
+     (mirroring benchmark_domain_heuristic.py exactly)
+  6. F1 vs ground truth (adjacency + orientation) on best (lowest-cost) model
+  7. CSV row write (always, even on timeout/error)
+
+Usage:
+    python runtime_scaling.py --n_nodes 14 --instance_id 3 \
+        --output_dir results/runtime_scaling/ --timeout_hours 35
+
+Notes on convention deviations vs gunfolds checklist (deliberate, follows
+prompt + benchmark_domain_heuristic.py exactly):
+  - selfloop=False (checklist #1 prefers None for PCMCI data; we follow the
+    benchmark to keep the encoding identical to the FBIRN scaling baseline
+    against which this experiment is compared).
+  - PCMCI: run_pcmci(tau_max=1, alpha=0.05, fdr_method='none')
+    (checklist #3 prefers pcmciplus tau_max=2 for fresh scripts; we follow
+    the benchmark since this experiment exists to measure the SCC speedup
+    on the same encoding the benchmark uses).
+  - density_mode='hard_soft0' (checklist #6 default is 'adaptive'; we follow
+    the benchmark's explicit choice).
+
+API note: gk.ring_sccs only accepts a single ring size for all SCCs and so
+cannot produce non-uniform compositions like 6+4+4.  This script therefore
+inlines the same construction (ringmore per SCC + DAG-quotient cross-edges
++ shift_list_labels + merge_list), letting us pass an arbitrary list of
+ring sizes while preserving gk.ring_sccs's algorithmic behaviour.  We do not
+call gk.ensure_gcd1 (it may add a self-loop) and explicitly strip any
+self-loops at the end.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import threading
+import traceback
+from datetime import datetime
+
+import numpy as np
+import random
+import networkx as nx
+import scipy.sparse as sp
+from scipy.sparse.linalg import eigs
+
+import clingo as clngo
+
+import tigramite.data_processing as pp
+from tigramite.pcmci import PCMCI
+from tigramite.independence_tests.parcorr import ParCorr
+
+# Make the repo importable when invoked as a script
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.join(_HERE, '..', '..', '..')
+sys.path.insert(0, _ROOT)
+
+from gunfolds.utils import bfutils
+from gunfolds.utils import graphkit as gk
+from gunfolds.utils.calc_procs import get_process_count
+from gunfolds import conversions as cv
+from gunfolds.conversions import drasl_jclingo2g
+from gunfolds.solvers.clingo_rasl import drasl_command
+from gunfolds.scripts.simulation import bold_function as hrf
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants — match benchmark_domain_heuristic.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+CLINGO_LIMIT = 64
+MAXCOST = 20
+PRIORITY = [1, 1, 1, 1, 2]
+DENSITY_MODE = 'hard_soft0'
+TOL_LOW = 5            # tighter than the FBIRN default (15) — synthetic gt_density
+                       # is lower (~14) so 15 % floor-clamps to 0 and removes the
+                       # lower cardinality bound entirely.
+TOL_HIGH = 5
+MAX_URATE = 4
+CAPSIZE = 0            # 0 = unlimited improving-model reports; with opt-mode=opt
+                       # clingo runs full BnB until optimality is proven.  -n 1
+                       # would stop at the first feasible model without optimising.
+
+# VAR + BOLD defaults — match exp4_pcmci_drasl_ringmore5.py defaults
+SSIZE = 2500
+NOISE = 0.1
+U_RATE = 2
+
+# SCC composition table (max SCC size = 6).  Documented in prompt.
+SCC_COMPOSITION = {
+    8:  [6, 2],
+    10: [6, 4],
+    12: [6, 6],
+    14: [6, 4, 4],
+    18: [6, 6, 6],
+    20: [6, 6, 4, 4],
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Determinism
+# ─────────────────────────────────────────────────────────────────────────────
+
+def derive_seed(n_nodes: int, instance_id: int) -> int:
+    h = hashlib.md5(f"{n_nodes}-{instance_id}".encode()).hexdigest()
+    return int(h[:8], 16)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ground-truth multi-SCC ring graph
+# ─────────────────────────────────────────────────────────────────────────────
+
+def make_multi_scc_ring(scc_sizes, dens=0.5, dag_degree=1, max_cross_connections=2):
+    """
+    Build a multi-SCC ring graph with the given (possibly non-uniform) ring
+    sizes, mirroring gk.ring_sccs but allowing per-SCC sizes and skipping
+    ensure_gcd1 (which may add a self-loop).
+
+    Returns (g, partition) where partition is a list of node-id lists, one
+    per SCC.  All node ids are 1-indexed (gunfolds convention).
+    """
+    num_sccs = len(scc_sizes)
+
+    # 1. Quotient DAG over the SCCs.  We avoid gk.randomDAG here: its inner
+    #    helper gk.remove_tril_singletons (graphkit.py:843) infinite-loops
+    #    for N<=2 because np.random.randint(0, N-1) excludes the upper bound
+    #    and returns 0 forever when an isolated node has index 0.  The
+    #    prompt requires "cross-ring arrows are forward only (a DAG over
+    #    the SCC quotient)", and the simplest such DAG is a chain
+    #    0->1->2->...->(num_sccs-1) — connected, weakly connected,
+    #    acyclic, and forward-only by construction.  Cross-SCC edge counts
+    #    remain randomised in step 3.
+    dag = nx.DiGraph()
+    dag.add_nodes_from(range(num_sccs))
+    for i in range(num_sccs - 1):
+        dag.add_edge(i, i + 1)
+
+    # 2. Build one ring-with-extra-edges per SCC, then shift node labels so
+    #    each SCC occupies its own contiguous id range.  We pick a per-ring
+    #    extra-edge count of 1 or 2 (prompt: "1-2 random extra non-self-loop
+    #    edges per ring"), capped by what ringmore can place without making
+    #    the ring trivially small.
+    rings = []
+    for s in scc_sizes:
+        # `dens * s^2 - s` is the gk.ring_sccs convention; clamp to [1, 2]
+        # to satisfy the prompt's 1-2 extra-edge spec.
+        n_extra = max(1, min(2, int(dens * s * s) - s))
+        rings.append(gk.ringmore(s, n_extra))
+    shifted = gk.shift_list_labels(rings)
+
+    # Track the partition before adding cross-SCC edges.  Each ring's nodes
+    # are exactly the keys of its (shifted) dict.
+    partition = [sorted(list(r.keys())) for r in shifted]
+
+    # 3. Random cross-SCC edges following the DAG (forward only — the
+    #    quotient DAG enforces a valid SCC structure).
+    for v in dag:
+        v_nodes = list(shifted[v].keys())
+        for w in dag[v]:
+            w_nodes = list(shifted[w].keys())
+            n_cross = np.random.randint(low=1, high=max_cross_connections + 1)
+            for _ in range(n_cross):
+                a = random.choice(v_nodes)
+                b = random.choice(w_nodes)
+                shifted[v][a][b] = 1
+
+    # 4. Merge into one graph and strip any accidental self-loops.
+    g = gk.merge_list(shifted)
+    for n in list(g.keys()):
+        if n in g[n]:
+            del g[n][n]
+
+    return g, partition
+
+
+def verify_partition(g, partition, max_scc_size):
+    """Hard-checks: partition matches actual SCCs of g, and no SCC > max."""
+    G = gk.graph2nx(g)
+    actual_sccs = [set(c) for c in nx.strongly_connected_components(G)]
+    declared_sccs = [set(p) for p in partition]
+
+    # All declared SCCs must equal an actual SCC (set equality, ignoring order)
+    for ds in declared_sccs:
+        if ds not in actual_sccs:
+            raise AssertionError(
+                f"Declared SCC {sorted(ds)} does not match any actual SCC. "
+                f"Actual SCCs: {[sorted(s) for s in actual_sccs]}"
+            )
+    # Number of declared SCCs must equal number of non-trivial-or-not SCCs
+    if len(declared_sccs) != len(actual_sccs):
+        raise AssertionError(
+            f"Declared {len(declared_sccs)} SCCs but graph has "
+            f"{len(actual_sccs)} actual SCCs."
+        )
+    for p in partition:
+        if len(p) > max_scc_size:
+            raise AssertionError(
+                f"SCC of size {len(p)} exceeds max_scc_size={max_scc_size}: {p}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VAR + BOLD simulation — match exp4_pcmci_drasl_ringmore5.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+def create_stable_weighted_matrix(A, threshold=0.1, powers=(1, 2, 3, 4),
+                                  max_attempts=1_000_000, damping=0.99):
+    for _ in range(max_attempts):
+        W = A * np.random.randn(*A.shape)
+        Ws = sp.csr_matrix(W)
+        evals, _ = eigs(Ws, k=1, which='LM')
+        rho = np.abs(evals[0])
+        if rho == 0:
+            continue
+        W *= damping / rho
+        ok = True
+        for n in powers:
+            Wn = np.linalg.matrix_power(W, n)
+            nz = np.nonzero(Wn)
+            if len(nz[0]) > 0 and (np.abs(Wn[nz]) < threshold).any():
+                ok = False
+                break
+        if ok:
+            return W
+    raise ValueError(f'Could not find stable matrix after {max_attempts} tries.')
+
+
+def simulate_var(W, ssize, noise):
+    n = W.shape[0]
+    data = np.zeros((n, ssize))
+    data[:, 0] = noise * np.random.randn(n)
+    for t in range(1, ssize):
+        data[:, t] = W @ data[:, t - 1] + noise * np.random.randn(n)
+    return data
+
+
+def simulate_bold(var_data, u_rate):
+    data_scaled = var_data / (np.abs(var_data).max() + 1e-12)
+    # end_time must scale with u_rate so the effective TR = 100/ssize * u_rate.
+    # Without this, generating ssize*u_rate VAR samples and then taking [::u_rate]
+    # cancels exactly and u_rate has no effect on the observed signal.
+    bold_out, _ = hrf.compute_bold_signals(data_scaled, end_time=100 * u_rate)
+    drop = bold_out.shape[1] // 5
+    bold_out = bold_out[:, drop:]
+    return bold_out[:, ::u_rate]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F1 metrics
+# ─────────────────────────────────────────────────────────────────────────────
+
+def graph_to_dir_adj(g, n):
+    """1-indexed gunfolds graph → 0-indexed n×n directed-adjacency matrix."""
+    adj = np.zeros((n, n), dtype=int)
+    for i, nbrs in g.items():
+        for j, v in nbrs.items():
+            if v in (1, 3):
+                adj[i - 1, j - 1] = 1
+    return adj
+
+
+def f1_from_counts(tp, fp, fn):
+    p = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    r = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+
+
+def evaluate_solution(pred_g, gt_g, n):
+    pred = graph_to_dir_adj(pred_g, n)
+    true = graph_to_dir_adj(gt_g, n)
+    np.fill_diagonal(pred, 0)
+    np.fill_diagonal(true, 0)
+
+    # Orientation: F1 over directed arrows
+    tp_o = int(np.sum((pred == 1) & (true == 1)))
+    fp_o = int(np.sum((pred == 1) & (true == 0)))
+    fn_o = int(np.sum((pred == 0) & (true == 1)))
+    orientation_f1 = f1_from_counts(tp_o, fp_o, fn_o)
+
+    # Adjacency: undirected presence — symmetrise both
+    pred_u = ((pred + pred.T) > 0).astype(int)
+    true_u = ((true + true.T) > 0).astype(int)
+    iu = np.triu_indices(n, k=1)
+    tp_a = int(np.sum((pred_u[iu] == 1) & (true_u[iu] == 1)))
+    fp_a = int(np.sum((pred_u[iu] == 1) & (true_u[iu] == 0)))
+    fn_a = int(np.sum((pred_u[iu] == 0) & (true_u[iu] == 1)))
+    adjacency_f1 = f1_from_counts(tp_a, fp_a, fn_a)
+
+    return adjacency_f1, orientation_f1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CSV row write
+# ─────────────────────────────────────────────────────────────────────────────
+
+CSV_COLUMNS = [
+    "n_nodes", "instance_id", "n_extra_edges", "scc_used", "scc_sizes",
+    "drasl_time_sec", "total_time_sec", "pcmci_time_sec", "bold_time_sec",
+    "n_solutions", "orientation_f1", "adjacency_f1", "status",
+]
+
+
+def write_csv_row(path, row):
+    """Write a one-header-line, one-data-row CSV."""
+    with open(path, "w") as f:
+        f.write(",".join(CSV_COLUMNS) + "\n")
+        vals = []
+        for col in CSV_COLUMNS:
+            v = row.get(col, "")
+            if isinstance(v, float) and np.isnan(v):
+                vals.append("")
+            elif isinstance(v, (list, tuple)):
+                vals.append(json.dumps(list(v)).replace(",", ";"))
+            elif isinstance(v, str) and ("," in v or '"' in v):
+                vals.append('"' + v.replace('"', '""') + '"')
+            else:
+                vals.append(str(v))
+        f.write(",".join(vals) + "\n")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main pipeline
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run_drasl_with_timeout(command, n_nodes, pnum, timeout_sec):
+    """
+    Mirror benchmark_domain_heuristic.py:run_scenario.  Build clingo.Control,
+    add+ground+solve under a threading.Timer.  Returns:
+        drasl_time_sec, n_solutions, best_pred_g_or_None, timed_out_bool
+    drasl_time_sec covers grounding + search (no I/O, no F1 calc).
+    """
+    base_args = [
+        "--warn=no-atom-undefined",
+        "--configuration=crafty",
+        "-t", f"{int(pnum)},split",
+        "-n", str(CAPSIZE),
+    ]
+    ctrl = clngo.Control(base_args)
+    ctrl.configuration.solve.opt_mode = "opt"
+
+    # Phase 1: program text + grounding + search — all timed together
+    t0 = time.perf_counter()
+    program = command.decode()
+    ctrl.add("base", [], program)
+    ctrl.ground([("base", [])])
+
+    models = []
+    timed_out = False
+    timer = None
+    if timeout_sec and timeout_sec > 0:
+        # Adjust the timer for the grounding time we already spent so the
+        # total drasl_time_sec budget is respected end-to-end.
+        elapsed_so_far = time.perf_counter() - t0
+        remaining = max(1.0, timeout_sec - elapsed_so_far)
+
+        def _interrupt():
+            nonlocal timed_out
+            timed_out = True
+            print(f"    *** TIMEOUT ({timeout_sec}s) — interrupting solver ***",
+                  flush=True)
+            ctrl.interrupt()
+        timer = threading.Timer(remaining, _interrupt)
+        timer.start()
+
+    try:
+        with ctrl.solve(yield_=True, async_=True) as handle:
+            for model in handle:
+                cost = model.cost
+                atoms = [str(a) for a in model.symbols(shown=True)]
+                models.append((atoms, cost))
+    finally:
+        if timer is not None:
+            timer.cancel()
+
+    drasl_time_sec = time.perf_counter() - t0
+
+    # Parse solutions; choose lowest-cost model as "best"
+    best_pred_g = None
+    if models:
+        # drasl_jclingo2g returns ((graph_num, urate), ...); each model's cost
+        # is a list of weighted-priority sums.  Pick lowest sum-of-cost.
+        scored = []
+        for atoms, cost in models:
+            parsed = drasl_jclingo2g(atoms)
+            cost_total = sum(cost) if cost else 0
+            scored.append((cost_total, parsed))
+        scored.sort(key=lambda t: t[0])
+        best_parsed = scored[0][1]
+        # drasl_jclingo2g returns a set or single tuple; normalise:
+        if isinstance(best_parsed, set):
+            best_parsed = next(iter(best_parsed))
+        graph_num = best_parsed[0]
+        best_pred_g = bfutils.num2CG(graph_num, n_nodes)
+
+    return drasl_time_sec, len(models), best_pred_g, timed_out
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Per-instance runtime scaling experiment for drasl on "
+                    "SCC-ring synthetic graphs."
+    )
+    parser.add_argument("--n_nodes", type=int, required=True,
+                        choices=sorted(SCC_COMPOSITION.keys()))
+    parser.add_argument("--instance_id", type=int, required=True)
+    parser.add_argument("--output_dir", type=str,
+                        default="results/runtime_scaling/")
+    parser.add_argument("--timeout_hours", type=float, default=35.0,
+                        help="drasl internal timeout (default 35h, 1h margin "
+                             "under the 36h SLURM walltime).")
+    parser.add_argument("--pnum", type=int,
+                        default=int(min(CLINGO_LIMIT, get_process_count(1))))
+    parser.add_argument("--ssize", type=int, default=SSIZE)
+    parser.add_argument("--noise", type=float, default=NOISE)
+    parser.add_argument("--u_rate", type=int, default=U_RATE)
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_path = os.path.join(
+        args.output_dir, f"n{args.n_nodes}_inst{args.instance_id}.csv")
+
+    timeout_sec = int(args.timeout_hours * 3600)
+    scc_sizes = SCC_COMPOSITION[args.n_nodes]
+
+    # Initialise a row that we will fill in as we go and write at the end —
+    # even on timeout / exception.
+    row = {
+        "n_nodes": args.n_nodes,
+        "instance_id": args.instance_id,
+        "n_extra_edges": "",
+        "scc_used": "",
+        "scc_sizes": scc_sizes,
+        "drasl_time_sec": float('nan'),
+        "total_time_sec": float('nan'),
+        "pcmci_time_sec": float('nan'),
+        "bold_time_sec": float('nan'),
+        "n_solutions": 0,
+        "orientation_f1": float('nan'),
+        "adjacency_f1": float('nan'),
+        "status": "",
+    }
+
+    overall_t0 = time.perf_counter()
+    print("=" * 70, flush=True)
+    print(f"runtime_scaling — n_nodes={args.n_nodes}, instance={args.instance_id}",
+          flush=True)
+    print(f"  scc_sizes={scc_sizes}  timeout={timeout_sec}s  "
+          f"pnum={args.pnum}", flush=True)
+    print(f"  start {datetime.now()}", flush=True)
+    print("=" * 70, flush=True)
+
+    try:
+        # ── Step 1: deterministic seed ────────────────────────────────────
+        seed = derive_seed(args.n_nodes, args.instance_id)
+        np.random.seed(seed)
+        random.seed(seed)
+        print(f"[1/5] seed = {seed}", flush=True)
+
+        # ── Step 2: ground-truth graph G^1 ────────────────────────────────
+        gt_g, partition = make_multi_scc_ring(
+            scc_sizes, dens=0.5, dag_degree=1, max_cross_connections=2)
+        verify_partition(gt_g, partition, max_scc_size=6)
+        n_nodes_actual = len(gt_g)
+        n_edges = sum(len(nbrs) for nbrs in gt_g.values())
+        # n_extra_edges relative to the bare ring topology
+        n_extra_edges = n_edges - sum(scc_sizes)
+        row["scc_used"] = json.dumps([len(p) for p in partition]).replace(",", ";")
+        row["n_extra_edges"] = n_extra_edges
+        print(f"[2/5] G^1: nodes={n_nodes_actual}, edges={n_edges}, "
+              f"partition_sizes={[len(p) for p in partition]}", flush=True)
+        assert n_nodes_actual == args.n_nodes, \
+            f"Built {n_nodes_actual} nodes but expected {args.n_nodes}"
+
+        # ── Step 3: VAR + BOLD ────────────────────────────────────────────
+        bold_t0 = time.perf_counter()
+        A = cv.graph2adj(gt_g)
+        W = create_stable_weighted_matrix(A, threshold=0.1, powers=(2, 3, 4))
+        var_data = simulate_var(W, ssize=args.ssize * args.u_rate,
+                                noise=args.noise)
+        bold_data = simulate_bold(var_data, u_rate=args.u_rate)
+        row["bold_time_sec"] = round(time.perf_counter() - bold_t0, 4)
+        print(f"[3/5] BOLD: shape={bold_data.shape}  "
+              f"({row['bold_time_sec']:.2f}s)", flush=True)
+
+        # ── Step 4: PCMCI ─────────────────────────────────────────────────
+        pcmci_t0 = time.perf_counter()
+        ts_2d = bold_data.T  # (T, N) for tigramite
+        assert ts_2d.shape[1] == n_nodes_actual, \
+            f"axis swap detected: ts_2d shape {ts_2d.shape}"
+        dataframe = pp.DataFrame(ts_2d)
+        pcmci = PCMCI(dataframe=dataframe, cond_ind_test=ParCorr(), verbosity=0)
+        pcmci_results = pcmci.run_pcmci(
+            tau_max=1, pc_alpha=None, alpha_level=0.05, fdr_method="none")
+        g_estimated, A_pc, B_pc = cv.Glag2CG(pcmci_results)
+        row["pcmci_time_sec"] = round(time.perf_counter() - pcmci_t0, 4)
+        print(f"[4/5] PCMCI: g_est nodes={len(g_estimated)}  "
+              f"({row['pcmci_time_sec']:.2f}s)", flush=True)
+
+        # ── Step 5: drasl ─────────────────────────────────────────────────
+        # DD/BD construction (canonical, MAXCOST=20)
+        a_max = np.abs(A_pc).max()
+        b_max = np.abs(B_pc).max()
+        if a_max > 0:
+            DD = (np.abs((np.abs(A_pc / a_max) +
+                          (cv.graph2adj(g_estimated) - 1)) * MAXCOST)).astype(int)
+        else:
+            DD = (np.abs((cv.graph2adj(g_estimated) - 1) * MAXCOST)).astype(int)
+        if b_max > 0:
+            BD = (np.abs((np.abs(B_pc / b_max) +
+                          (cv.graph2badj(g_estimated) - 1)) * MAXCOST)).astype(int)
+        else:
+            BD = (np.abs((cv.graph2badj(g_estimated) - 1) * MAXCOST)).astype(int)
+
+        urate = min(MAX_URATE, 3 * n_nodes_actual + 1)
+        # GT_density derived from G^1 (per-instance, in 0-100 convention).
+        gt_density = max(1, int(round(100.0 * gk.density(gt_g))))
+
+        # Pass scc_members = ground-truth SCC partition (this experiment knows
+        # G^1).  dm=[DD] activates the weighted-MFAS quotient back-edge
+        # selection inside encode_list_sccs (CHANGELOG_AI 2026-05-04).
+        # selfloop=False mirrors benchmark_domain_heuristic.py.
+        command = drasl_command(
+            [g_estimated],
+            max_urate=urate,
+            weighted=True,
+            scc=True,
+            scc_members=partition,
+            dm=[DD], bdm=[BD],
+            edge_weights=PRIORITY,
+            GT_density=gt_density,
+            selfloop=False,
+            density_mode=DENSITY_MODE,
+            tol=None, tol_low=TOL_LOW, tol_high=TOL_HIGH,
+        )
+        print(f"[5/5] drasl: ASP {len(command):,} bytes  urate={urate}  "
+              f"gt_density={gt_density}  scc={[len(p) for p in partition]}",
+              flush=True)
+        print(f"        DD range [{DD.min()},{DD.max()}]  "
+              f"BD range [{BD.min()},{BD.max()}]", flush=True)
+
+        drasl_time_sec, n_solutions, best_pred_g, timed_out = (
+            run_drasl_with_timeout(command, n_nodes_actual, args.pnum, timeout_sec)
+        )
+        row["drasl_time_sec"] = round(drasl_time_sec, 4)
+        row["n_solutions"] = n_solutions
+        print(f"        drasl done: {drasl_time_sec:.2f}s  "
+              f"n_solutions={n_solutions}  timed_out={timed_out}", flush=True)
+
+        # F1 vs ground truth
+        if best_pred_g is not None:
+            adj_f1, orient_f1 = evaluate_solution(
+                best_pred_g, gt_g, n_nodes_actual)
+            row["adjacency_f1"] = round(adj_f1, 4)
+            row["orientation_f1"] = round(orient_f1, 4)
+            print(f"        F1: adjacency={adj_f1:.3f}  "
+                  f"orientation={orient_f1:.3f}", flush=True)
+
+        row["status"] = "timeout" if timed_out else "completed"
+
+    except Exception as exc:
+        tb = traceback.format_exc()
+        print(f"\n!! ERROR: {exc}\n{tb}", flush=True)
+        # Truncate the message for the CSV but keep enough to debug.
+        msg = str(exc).replace("\n", " ").replace(",", ";")[:200]
+        row["status"] = f"error: {msg}"
+
+    row["total_time_sec"] = round(time.perf_counter() - overall_t0, 4)
+    write_csv_row(out_path, row)
+    print(f"\nWrote {out_path}  status={row['status']}  "
+          f"total={row['total_time_sec']:.1f}s", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -491,13 +491,15 @@ def main():
         # ── Step 3: VAR + BOLD ────────────────────────────────────────────
         bold_t0 = time.perf_counter()
         A = cv.graph2adj(gt_g)
-        # threshold=0.01, powers=(2,) — relaxed from exp4's (0.1, (2,3,4)) which
-        # was tuned for N=5.  For sparse graphs at N=42+, products of small
-        # weights along length-3/4 paths fall below 0.1 in essentially every
-        # random draw, so the original filter never accepted any W.  The
-        # spectral-radius stability check (rho < 1) is the bit that actually
-        # matters for the VAR; the threshold is a loose path-strength check.
-        W = create_stable_weighted_matrix(A, threshold=0.01, powers=(2,))
+        # powers=() disables the path-strength filter entirely.  exp4 tuned
+        # threshold=0.1, powers=(1,2,3,4) for N=5; even relaxed to 0.01 / (2,)
+        # this filter rejected every random W for N>=18 (W^2 entries along
+        # sparse paths fall below any positive threshold a sizable fraction
+        # of the time, regardless of damping).  The VAR's stability is fully
+        # determined by spectral radius < 1, which is enforced by the
+        # damping/rho normalisation inside create_stable_weighted_matrix —
+        # no extra filter is needed.
+        W = create_stable_weighted_matrix(A, threshold=0.0, powers=())
         var_data = simulate_var(W, ssize=args.ssize * args.u_rate,
                                 noise=args.noise)
         bold_data = simulate_bold(var_data, u_rate=args.u_rate)

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -491,7 +491,13 @@ def main():
         # ── Step 3: VAR + BOLD ────────────────────────────────────────────
         bold_t0 = time.perf_counter()
         A = cv.graph2adj(gt_g)
-        W = create_stable_weighted_matrix(A, threshold=0.1, powers=(2, 3, 4))
+        # threshold=0.01, powers=(2,) — relaxed from exp4's (0.1, (2,3,4)) which
+        # was tuned for N=5.  For sparse graphs at N=42+, products of small
+        # weights along length-3/4 paths fall below 0.1 in essentially every
+        # random draw, so the original filter never accepted any W.  The
+        # spectral-radius stability check (rho < 1) is the bit that actually
+        # matters for the VAR; the threshold is a loose path-strength check.
+        W = create_stable_weighted_matrix(A, threshold=0.01, powers=(2,))
         var_data = simulate_var(W, ssize=args.ssize * args.u_rate,
                                 noise=args.noise)
         bold_data = simulate_bold(var_data, u_rate=args.u_rate)

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -218,11 +218,15 @@ def verify_partition(g, partition, max_scc_size):
 
 def create_stable_weighted_matrix(A, threshold=0.1, powers=(1, 2, 3, 4),
                                   max_attempts=1_000_000, damping=0.99):
+    # NOTE: exp4_pcmci_drasl_ringmore5.py used `scipy.sparse.linalg.eigs(Ws, k=1)`
+    # here (Arnoldi/ARPACK iterative method).  For N >= ~50 this routinely
+    # fails to converge on random W ("ARPACK error -1: No convergence"),
+    # killing the job before drasl runs.  Dense `np.linalg.eigvals` is fast
+    # and robust at our sizes (N <= 54), so we use it instead.
     for _ in range(max_attempts):
         W = A * np.random.randn(*A.shape)
-        Ws = sp.csr_matrix(W)
-        evals, _ = eigs(Ws, k=1, which='LM')
-        rho = np.abs(evals[0])
+        evals = np.linalg.eigvals(W)
+        rho = np.abs(evals).max()
         if rho == 0:
             continue
         W *= damping / rho

--- a/gunfolds/scripts/experiments/runtime_scaling.py
+++ b/gunfolds/scripts/experiments/runtime_scaling.py
@@ -252,11 +252,32 @@ def simulate_var(W, ssize, noise):
 
 
 def simulate_bold(var_data, u_rate):
-    data_scaled = var_data / (np.abs(var_data).max() + 1e-12)
     # end_time must scale with u_rate so the effective TR = 100/ssize * u_rate.
     # Without this, generating ssize*u_rate VAR samples and then taking [::u_rate]
     # cancels exactly and u_rate has no effect on the observed signal.
-    bold_out, _ = hrf.compute_bold_signals(data_scaled, end_time=100 * u_rate)
+    #
+    # Numerical-stability retry: for large N, random VAR transients can push
+    # the balloon-model ODE past `vode`'s error tolerance on a single node;
+    # that node's output is then shorter than the others and np.array() in
+    # compute_bold_signals returns a 1-D object array (`.ndim == 1`), which
+    # blows up `bold_out.shape[1]`.  Detect that and retry with the input
+    # rescaled tighter — smaller drive ⇒ gentler dynamics ⇒ stable integration.
+    extra_scale = 1.0
+    bold_out = None
+    for _ in range(5):
+        data_scaled = var_data / (np.abs(var_data).max() * extra_scale + 1e-12)
+        bold_out, _ = hrf.compute_bold_signals(data_scaled, end_time=100 * u_rate)
+        if bold_out.ndim == 2 and bold_out.shape[1] > 0:
+            break
+        extra_scale *= 3.0
+        print(f"    [simulate_bold] BOLD ODE failed (ragged output); "
+              f"retrying with input rescaled by {extra_scale:g}x", flush=True)
+    else:
+        raise RuntimeError(
+            "simulate_bold: BOLD ODE integrator failed even after rescaling "
+            f"input by {extra_scale:g}x.  This VAR realisation may be "
+            "intrinsically unstable for the balloon model."
+        )
     drop = bold_out.shape[1] // 5
     bold_out = bold_out[:, drop:]
     return bold_out[:, ::u_rate]

--- a/gunfolds/scripts/experiments/submit_pcmci_alpha_sweep.sh
+++ b/gunfolds/scripts/experiments/submit_pcmci_alpha_sweep.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# =============================================================================
+# Submit pcmci_alpha_sweep.py as a SLURM array — one task per alpha value.
+#
+# Decoupled from drasl: this script only runs the PCMCI front-end at multiple
+# alpha values so you can pick a good alpha by the Exp 4 composite score
+# (0.6 × cross-subject Jaccard + 0.4 × density proximity) without paying the
+# multi-day drasl cost. PCMCI at N=53 is ~10–60 s per subject; the full sweep
+# completes in a few hours rather than weeks.
+#
+# Memory/CPU/time are sized for PCMCI alone, not drasl. PCMCI is single-
+# threaded, so we ask for 2 CPUs (one for PCMCI, one for OS overhead) and
+# memory scales with N: 4 GB (N=10), 8 GB (N=20), 16 GB (N=53).
+#
+# Usage (run from anywhere; paths are resolved relative to this script):
+#   bash submit_pcmci_alpha_sweep.sh 53
+#   bash submit_pcmci_alpha_sweep.sh 10
+#
+# Override alpha grid:
+#   ALPHAS="0.005 0.01 0.02 0.05 0.1" bash submit_pcmci_alpha_sweep.sh 53
+# =============================================================================
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash submit_pcmci_alpha_sweep.sh <N>   where N in {10, 20, 53}"
+    exit 1
+fi
+
+N="$1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/pcmci_alpha_sweep.py"
+
+OUTPUT_DIR="results/pcmci_alpha_sweep_N${N}"
+LOG_DIR="logs/pcmci_alpha_sweep_N${N}"
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+
+# ─── SLURM constants ─────────────────────────────────────────────────────────
+PARTITION="qTRD"             # CPU partition — no GPU needed for PCMCI
+ACCOUNT="psy53c17"
+EMAIL="mabavisani@gsu.edu"
+CPUS=2
+
+case "$N" in
+    10) MEM="4g";  WALLTIME="00:30:00" ;;
+    20) MEM="8g";  WALLTIME="02:00:00" ;;
+    53) MEM="16g"; WALLTIME="06:00:00" ;;
+    *)  echo "Unsupported N=$N (allowed: 10, 20, 53)"; exit 1 ;;
+esac
+
+# Default alpha grid (overridable via env)
+ALPHAS="${ALPHAS:-0.005 0.01 0.02 0.03 0.05 0.08 0.10}"
+read -ra ALPHA_ARR <<< "$ALPHAS"
+N_ALPHAS=${#ALPHA_ARR[@]}
+LAST_IDX=$((N_ALPHAS - 1))
+
+echo "Submitting PCMCI alpha sweep for N=${N}"
+echo "  alphas:    ${ALPHAS}  (${N_ALPHAS} values)"
+echo "  partition: ${PARTITION}    mem=${MEM}  cpus=${CPUS}  time=${WALLTIME}"
+echo "  output:    ${OUTPUT_DIR}/"
+
+JOB_ID=$(sbatch \
+    --parsable \
+    -J "pcmci_alpha_N${N}" \
+    -p "$PARTITION" \
+    -A "$ACCOUNT" \
+    --mail-type=FAIL,END \
+    --mail-user="$EMAIL" \
+    -N 1 -n 1 \
+    --cpus-per-task=${CPUS} \
+    --mem=${MEM} \
+    -t "$WALLTIME" \
+    --array=0-${LAST_IDX} \
+    -o "${LOG_DIR}/alpha_%a.out" \
+    -e "${LOG_DIR}/alpha_%a.err" \
+    --wrap "#!/bin/bash
+        set -e
+        export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK:-${CPUS}}
+        . /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
+        conda activate multi_v3
+        cd \$SLURM_SUBMIT_DIR
+        ALPHAS=(${ALPHAS})
+        ALPHA=\${ALPHAS[\$SLURM_ARRAY_TASK_ID]}
+        echo \"task \$SLURM_ARRAY_TASK_ID -> alpha=\$ALPHA\"
+        python ${RUNNER} \
+            --alpha \$ALPHA \
+            --n_components ${N} \
+            --output_dir ${OUTPUT_DIR}
+    ")
+
+echo ""
+echo "Submitted job array ${JOB_ID} (${N_ALPHAS} tasks)"
+echo ""
+echo "Monitor:"
+echo "  squeue -j ${JOB_ID}"
+echo "  tail -f ${LOG_DIR}/alpha_0.out"
+echo ""
+echo "After completion, aggregate:"
+echo "  python ${SCRIPT_DIR}/aggregate_pcmci_sweep.py \\"
+echo "      --input_dir ${OUTPUT_DIR} --n_components ${N} \\"
+echo "      --output_csv ${OUTPUT_DIR}/summary.csv"

--- a/gunfolds/scripts/experiments/submit_pcmci_alpha_sweep.sh
+++ b/gunfolds/scripts/experiments/submit_pcmci_alpha_sweep.sh
@@ -74,14 +74,13 @@ JOB_ID=$(sbatch \
     --array=0-${LAST_IDX} \
     -o "${LOG_DIR}/alpha_%a.out" \
     -e "${LOG_DIR}/alpha_%a.err" \
-    --wrap "#!/bin/bash
-        set -e
+    --wrap "set -e
         export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK:-${CPUS}}
         . /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
         conda activate multi_v3
         cd \$SLURM_SUBMIT_DIR
-        ALPHAS=(${ALPHAS})
-        ALPHA=\${ALPHAS[\$SLURM_ARRAY_TASK_ID]}
+        # POSIX-safe alpha pick: --wrap runs under /bin/sh (dash), no bash arrays.
+        ALPHA=\$(echo '${ALPHAS}' | awk -v i=\$((SLURM_ARRAY_TASK_ID + 1)) '{print \$i}')
         echo \"task \$SLURM_ARRAY_TASK_ID -> alpha=\$ALPHA\"
         python ${RUNNER} \
             --alpha \$ALPHA \

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# =============================================================================
+# Submit the drasl runtime-scaling experiment as 60 SLURM jobs:
+#   N ∈ {8, 10, 12, 14, 18, 20}  ×  10 instances  =  60 jobs.
+#
+# Single global walltime: 36 hours.  drasl internal timeout: 35 hours
+# (1-hour safety margin so the script can write a "timeout" CSV row before
+# being killed).
+#
+# RAM scales with N (drasl grounding footprint grows with N).
+#
+# Submission pattern: one sbatch per (n_nodes, instance_id) pair, mirroring
+# how submit_fmri_experiment.sh dispatches per-config arrays.  We do NOT
+# bundle into a single SLURM array because per-N RAM allocations differ.
+#
+# Usage:
+#   bash submit_runtime_scaling.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/runtime_scaling.py"
+
+OUTPUT_DIR="results/runtime_scaling"
+LOG_DIR="logs/runtime_scaling"
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+
+# ─── SLURM constants (match slurm_fmri_large.sh conventions) ─────────────────
+PARTITION="qTRDGPU"
+ACCOUNT="psy53c17"
+EMAIL="mabavisani@gsu.edu"
+WALLTIME="36:00:00"
+CPUS=16              # 15 clingo threads + 1 buffer
+TIMEOUT_HOURS=35
+
+# Per-N RAM tier
+declare -A MEM_BY_N=(
+    [8]="8g"  [10]="8g"
+    [12]="32g" [14]="32g"
+    [18]="64g" [20]="64g"
+)
+
+N_VALUES=(8 10 12 14 18 20)
+INSTANCES_PER_N=10
+
+JOB_IDS=()
+
+for N in "${N_VALUES[@]}"; do
+    MEM="${MEM_BY_N[$N]}"
+    for ((I=0; I<INSTANCES_PER_N; I++)); do
+        JOB_NAME="rt_n${N}_i${I}"
+        OUT_LOG="${LOG_DIR}/n${N}_inst${I}.out"
+        ERR_LOG="${LOG_DIR}/n${N}_inst${I}.err"
+
+        JOB_ID=$(sbatch \
+            --parsable \
+            -J "$JOB_NAME" \
+            -p "$PARTITION" \
+            -A "$ACCOUNT" \
+            --mail-type=FAIL \
+            --mail-user="$EMAIL" \
+            -N 1 -n 1 \
+            --cpus-per-task=${CPUS} \
+            --mem=${MEM} \
+            -t "$WALLTIME" \
+            -o "$OUT_LOG" \
+            -e "$ERR_LOG" \
+            --wrap "
+                set -e
+                export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK:-${CPUS}}
+                export MODULEPATH=/apps/Compilers/modules-3.2.10/Debug-Build/Modules/3.2.10/modulefiles/
+                source /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
+                conda activate multi_v3
+                cd \$SLURM_SUBMIT_DIR
+                python ${RUNNER} \
+                    --n_nodes ${N} \
+                    --instance_id ${I} \
+                    --output_dir ${OUTPUT_DIR} \
+                    --timeout_hours ${TIMEOUT_HOURS}
+            ")
+        JOB_IDS+=("$JOB_ID")
+        printf "  submitted N=%-2s  inst=%-2s  mem=%-4s  JobID=%s\n" \
+            "$N" "$I" "$MEM" "$JOB_ID"
+    done
+done
+
+echo ""
+echo "=============================================================="
+echo "SUBMISSION COMPLETE"
+echo "=============================================================="
+echo "Total jobs:    ${#JOB_IDS[@]}  (expected 60)"
+echo "Output dir:    ${OUTPUT_DIR}/"
+echo "Log dir:       ${LOG_DIR}/"
+echo "Walltime/job:  ${WALLTIME}"
+echo "Aggregate when done:"
+echo "  python ${SCRIPT_DIR}/aggregate_results.py --input_dir ${OUTPUT_DIR}"
+echo ""
+
+# Save submission record
+RECORD="${LOG_DIR}/submission_$(date +%m%d%Y%H%M%S).log"
+{
+    echo "Submitted: $(date)"
+    echo "Walltime:  ${WALLTIME}"
+    echo "CPUs:      ${CPUS}"
+    echo "Job IDs:   ${JOB_IDS[*]}"
+} > "$RECORD"
+echo "Submission record: $RECORD"

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -49,7 +49,11 @@ declare -A MEM_BY_N=(
 N_VALUES=(8 10 12 14 18 20 24 30 42 54)
 INSTANCES_PER_N=10
 
+# Set FORCE=1 to disable the skip-if-completed guard and resubmit everything.
+FORCE="${FORCE:-0}"
+
 JOB_IDS=()
+SKIPPED=0
 
 for N in "${N_VALUES[@]}"; do
     MEM="${MEM_BY_N[$N]}"
@@ -57,6 +61,15 @@ for N in "${N_VALUES[@]}"; do
         JOB_NAME="rt_n${N}_i${I}"
         OUT_LOG="${LOG_DIR}/n${N}_inst${I}.out"
         ERR_LOG="${LOG_DIR}/n${N}_inst${I}.err"
+        CSV="${OUTPUT_DIR}/n${N}_inst${I}.csv"
+
+        # Skip if a previous run already wrote a completed CSV (status == "completed").
+        # Override with FORCE=1 to resubmit.
+        if [ "$FORCE" != "1" ] && [ -f "$CSV" ] && tail -n 1 "$CSV" | grep -q ',completed$'; then
+            printf "  [skip] N=%-2s  inst=%-2s  (already completed)\n" "$N" "$I"
+            SKIPPED=$((SKIPPED + 1))
+            continue
+        fi
 
         JOB_ID=$(sbatch \
             --parsable \
@@ -95,7 +108,7 @@ echo ""
 echo "=============================================================="
 echo "SUBMISSION COMPLETE"
 echo "=============================================================="
-echo "Total jobs:    ${#JOB_IDS[@]}  (expected 100 — 10 N-values × 10 instances)"
+echo "Total jobs:    ${#JOB_IDS[@]}  submitted   (skipped ${SKIPPED} already-completed)"
 echo "Output dir:    ${OUTPUT_DIR}/"
 echo "Log dir:       ${LOG_DIR}/"
 echo "Walltime/job:  ${WALLTIME}"

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -71,11 +71,11 @@ for N in "${N_VALUES[@]}"; do
             -t "$WALLTIME" \
             -o "$OUT_LOG" \
             -e "$ERR_LOG" \
-            --wrap "
+            --wrap "#!/bin/bash
                 set -e
                 export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK:-${CPUS}}
                 export MODULEPATH=/apps/Compilers/modules-3.2.10/Debug-Build/Modules/3.2.10/modulefiles/
-                source /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
+                . /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
                 conda activate multi_v3
                 cd \$SLURM_SUBMIT_DIR
                 python ${RUNNER} \

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -82,7 +82,8 @@ for N in "${N_VALUES[@]}"; do
                     --n_nodes ${N} \
                     --instance_id ${I} \
                     --output_dir ${OUTPUT_DIR} \
-                    --timeout_hours ${TIMEOUT_HOURS}
+                    --timeout_hours ${TIMEOUT_HOURS} \
+                    --pnum \${SLURM_CPUS_PER_TASK:-15}
             ")
         JOB_IDS+=("$JOB_ID")
         printf "  submitted N=%-2s  inst=%-2s  mem=%-4s  JobID=%s\n" \

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -49,11 +49,18 @@ declare -A MEM_BY_N=(
 N_VALUES=(8 10 12 14 18 20 24 30 42 54)
 INSTANCES_PER_N=10
 
-# Set FORCE=1 to disable the skip-if-completed guard and resubmit everything.
+# Set FORCE=1 to disable both skip guards and resubmit everything.
 FORCE="${FORCE:-0}"
 
+# Snapshot of currently-queued/running job names for this user (cheap, one squeue call).
+RUNNING_NAMES=""
+if [ "$FORCE" != "1" ]; then
+    RUNNING_NAMES=$(squeue -u "$USER" -h -o "%j" 2>/dev/null || true)
+fi
+
 JOB_IDS=()
-SKIPPED=0
+SKIPPED_DONE=0
+SKIPPED_RUNNING=0
 
 for N in "${N_VALUES[@]}"; do
     MEM="${MEM_BY_N[$N]}"
@@ -63,11 +70,17 @@ for N in "${N_VALUES[@]}"; do
         ERR_LOG="${LOG_DIR}/n${N}_inst${I}.err"
         CSV="${OUTPUT_DIR}/n${N}_inst${I}.csv"
 
-        # Skip if a previous run already wrote a completed CSV (status == "completed").
-        # Override with FORCE=1 to resubmit.
+        # Skip 1: a previous run already wrote a completed CSV.
         if [ "$FORCE" != "1" ] && [ -f "$CSV" ] && tail -n 1 "$CSV" | grep -q ',completed$'; then
             printf "  [skip] N=%-2s  inst=%-2s  (already completed)\n" "$N" "$I"
-            SKIPPED=$((SKIPPED + 1))
+            SKIPPED_DONE=$((SKIPPED_DONE + 1))
+            continue
+        fi
+
+        # Skip 2: a job with this name is already queued or running.
+        if [ "$FORCE" != "1" ] && echo "$RUNNING_NAMES" | grep -qxF "$JOB_NAME"; then
+            printf "  [skip] N=%-2s  inst=%-2s  (already in queue: %s)\n" "$N" "$I" "$JOB_NAME"
+            SKIPPED_RUNNING=$((SKIPPED_RUNNING + 1))
             continue
         fi
 
@@ -108,7 +121,7 @@ echo ""
 echo "=============================================================="
 echo "SUBMISSION COMPLETE"
 echo "=============================================================="
-echo "Total jobs:    ${#JOB_IDS[@]}  submitted   (skipped ${SKIPPED} already-completed)"
+echo "Total jobs:    ${#JOB_IDS[@]} submitted  (skipped ${SKIPPED_DONE} completed, ${SKIPPED_RUNNING} already-queued)"
 echo "Output dir:    ${OUTPUT_DIR}/"
 echo "Log dir:       ${LOG_DIR}/"
 echo "Walltime/job:  ${WALLTIME}"

--- a/gunfolds/scripts/experiments/submit_runtime_scaling.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # =============================================================================
-# Submit the drasl runtime-scaling experiment as 60 SLURM jobs:
-#   N ∈ {8, 10, 12, 14, 18, 20}  ×  10 instances  =  60 jobs.
+# Submit the drasl runtime-scaling experiment as 100 SLURM jobs:
+#   N ∈ {8, 10, 12, 14, 18, 20, 24, 30, 42, 54}  ×  10 instances  =  100 jobs.
+#   N >= 24 use uniform 6-node SCCs (so 24=4×6, 30=5×6, 42=7×6, 54=9×6).
 #
 # Single global walltime: 36 hours.  drasl internal timeout: 35 hours
 # (1-hour safety margin so the script can write a "timeout" CSV row before
@@ -34,14 +35,18 @@ WALLTIME="36:00:00"
 CPUS=16              # 15 clingo threads + 1 buffer
 TIMEOUT_HOURS=35
 
-# Per-N RAM tier
+# Per-N RAM tier — drasl grounding footprint scales with N² × urate, so
+# larger graphs need progressively more memory.
 declare -A MEM_BY_N=(
-    [8]="8g"  [10]="8g"
+    [8]="8g"   [10]="8g"
     [12]="32g" [14]="32g"
     [18]="64g" [20]="64g"
+    [24]="128g" [30]="128g"
+    [42]="192g"
+    [54]="256g"
 )
 
-N_VALUES=(8 10 12 14 18 20)
+N_VALUES=(8 10 12 14 18 20 24 30 42 54)
 INSTANCES_PER_N=10
 
 JOB_IDS=()
@@ -89,7 +94,7 @@ echo ""
 echo "=============================================================="
 echo "SUBMISSION COMPLETE"
 echo "=============================================================="
-echo "Total jobs:    ${#JOB_IDS[@]}  (expected 60)"
+echo "Total jobs:    ${#JOB_IDS[@]}  (expected 100 — 10 N-values × 10 instances)"
 echo "Output dir:    ${OUTPUT_DIR}/"
 echo "Log dir:       ${LOG_DIR}/"
 echo "Walltime/job:  ${WALLTIME}"

--- a/gunfolds/scripts/experiments/submit_runtime_scaling_large.sh
+++ b/gunfolds/scripts/experiments/submit_runtime_scaling_large.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# =============================================================================
+# Submit ONE instance each at N=30, N=42, N=54 — the regime where the previous
+# 100-job sweep timed out at the old 36h wall.  This script asks for the
+# cluster's maximum walltime (5d 8h = 128h) and memory tuned to ~1.6× the
+# worst MaxRSS observed in sacct for that N (so we stay comfortably under
+# the per-CPU memory ceiling and don't get silently bumped to extra CPUs).
+#
+# Memory tier (revised — N=54 maxed out, N=30 & N=42 quadrupled):
+#   N=30 → 160 GB  (4× the original 40 GB)
+#   N=42 → 256 GB  (4× the original 64 GB)
+#   N=54 → 480 GB  (close to qTRDGPU node max of 512 GB, leaving ~32 GB for OS)
+# CPUs are sized explicitly per-N to keep mem/cpu ≤ 15 GB (qTRDGPU's
+# MaxMemPerCPU); without this, SLURM silently bumps --cpus-per-task to
+# satisfy the ratio.  Sizing:
+#   N=30 → 11 CPUs (160/15 = 10.7)
+#   N=42 → 18 CPUs (256/15 = 17.1)
+#   N=54 → 32 CPUs (480/15 = 32.0; also = half of a 64-CPU qTRDGPU node)
+# All three fit within a single qTRDGPU node (64 CPUs / 512 GB).
+#
+# drasl internal timeout: 127h (1h safety margin under the 128h SLURM kill,
+# so the runner can write a timeout CSV row before being SIGKILL'd).
+#
+# Uses the new --w_bias_magnitudes flag so VAR-W draws are scale-aware and
+# magnitude-biased (see runtime_scaling.py:create_stable_weighted_matrix).
+#
+# Usage:
+#   bash submit_runtime_scaling_large.sh           # uses instance_id=0
+#   INSTANCE_ID=3 bash submit_runtime_scaling_large.sh
+#   FORCE=1 bash submit_runtime_scaling_large.sh   # skip "already completed" guard
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/runtime_scaling.py"
+
+OUTPUT_DIR="results/runtime_scaling"
+LOG_DIR="logs/runtime_scaling"
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+
+# ─── SLURM constants ─────────────────────────────────────────────────────────
+PARTITION="qTRDGPU"
+ACCOUNT="psy53c17"
+EMAIL="mabavisani@gsu.edu"
+WALLTIME="5-08:00:00"   # 5 days 8 hours — partition maximum (qTRD/qTRDGPU/qTRDHM)
+TIMEOUT_HOURS=127        # 1h margin under SLURM wall
+
+INSTANCE_ID="${INSTANCE_ID:-0}"
+FORCE="${FORCE:-0}"
+
+# Per-N RAM and CPU tiers — N=54 maxed to ~480GB (qTRDGPU node has 512GB);
+# N=30 and N=42 are 4× the original sizing.  CPUs are scaled to keep
+# mem/cpu ≤ 15 GB so SLURM doesn't silently bump --cpus-per-task.
+declare -A MEM_BY_N=(
+    [30]="160g"
+    [42]="256g"
+    [54]="480g"
+)
+declare -A CPUS_BY_N=(
+    [30]=11
+    [42]=18
+    [54]=32
+)
+N_VALUES=(30 42 54)
+
+RUNNING_NAMES=""
+if [ "$FORCE" != "1" ]; then
+    RUNNING_NAMES=$(squeue -u "$USER" -h -o "%j" 2>/dev/null || true)
+fi
+
+JOB_IDS=()
+SKIPPED_DONE=0
+SKIPPED_RUNNING=0
+
+for N in "${N_VALUES[@]}"; do
+    MEM="${MEM_BY_N[$N]}"
+    CPUS="${CPUS_BY_N[$N]}"
+    I="$INSTANCE_ID"
+    JOB_NAME="rt_n${N}_i${I}_long"
+    OUT_LOG="${LOG_DIR}/n${N}_inst${I}_long.out"
+    ERR_LOG="${LOG_DIR}/n${N}_inst${I}_long.err"
+    CSV="${OUTPUT_DIR}/n${N}_inst${I}.csv"
+
+    if [ "$FORCE" != "1" ] && [ -f "$CSV" ] && tail -n 1 "$CSV" | grep -q ',completed$'; then
+        printf "  [skip] N=%-2s  inst=%-2s  (already completed)\n" "$N" "$I"
+        SKIPPED_DONE=$((SKIPPED_DONE + 1))
+        continue
+    fi
+
+    if [ "$FORCE" != "1" ] && echo "$RUNNING_NAMES" | grep -qxF "$JOB_NAME"; then
+        printf "  [skip] N=%-2s  inst=%-2s  (already in queue: %s)\n" "$N" "$I" "$JOB_NAME"
+        SKIPPED_RUNNING=$((SKIPPED_RUNNING + 1))
+        continue
+    fi
+
+    JOB_ID=$(sbatch \
+        --parsable \
+        -J "$JOB_NAME" \
+        -p "$PARTITION" \
+        -A "$ACCOUNT" \
+        --mail-type=FAIL,END \
+        --mail-user="$EMAIL" \
+        -N 1 -n 1 \
+        --cpus-per-task=${CPUS} \
+        --mem=${MEM} \
+        -t "$WALLTIME" \
+        -o "$OUT_LOG" \
+        -e "$ERR_LOG" \
+        --wrap "#!/bin/bash
+            set -e
+            export OMP_NUM_THREADS=\${SLURM_CPUS_PER_TASK:-${CPUS}}
+            export MODULEPATH=/apps/Compilers/modules-3.2.10/Debug-Build/Modules/3.2.10/modulefiles/
+            . /home/users/mabavisani/anaconda3/etc/profile.d/conda.sh
+            conda activate multi_v3
+            cd \$SLURM_SUBMIT_DIR
+            python ${RUNNER} \
+                --n_nodes ${N} \
+                --instance_id ${I} \
+                --output_dir ${OUTPUT_DIR} \
+                --timeout_hours ${TIMEOUT_HOURS} \
+                --pnum \${SLURM_CPUS_PER_TASK:-15} \
+                --w_bias_magnitudes
+        ")
+    JOB_IDS+=("$JOB_ID")
+    printf "  submitted N=%-2s  inst=%-2s  cpus=%-2s  mem=%-5s  walltime=%s  JobID=%s\n" \
+        "$N" "$I" "$CPUS" "$MEM" "$WALLTIME" "$JOB_ID"
+done
+
+echo ""
+echo "=============================================================="
+echo "LARGE-N RESUBMISSION COMPLETE"
+echo "=============================================================="
+echo "Jobs submitted: ${#JOB_IDS[@]}  (skipped ${SKIPPED_DONE} completed, ${SKIPPED_RUNNING} already-queued)"
+echo "Walltime/job:   ${WALLTIME}  (drasl --timeout_hours=${TIMEOUT_HOURS})"
+echo "Output dir:     ${OUTPUT_DIR}/"
+echo "Log dir:        ${LOG_DIR}/"
+echo ""
+
+RECORD="${LOG_DIR}/submission_large_$(date +%m%d%Y%H%M%S).log"
+{
+    echo "Submitted: $(date)"
+    echo "Walltime:  ${WALLTIME}"
+    echo "Instance:  ${INSTANCE_ID}"
+    for N in "${N_VALUES[@]}"; do
+        echo "  N=${N}  cpus=${CPUS_BY_N[$N]}  mem=${MEM_BY_N[$N]}"
+    done
+    echo "Job IDs:   ${JOB_IDS[*]}"
+} > "$RECORD"
+echo "Submission record: $RECORD"

--- a/gunfolds/scripts/real_data/fmri_experiment_large.py
+++ b/gunfolds/scripts/real_data/fmri_experiment_large.py
@@ -130,7 +130,7 @@ def parse_arguments():
                    help="PCMCI variant: pcmciplus (more stable, recommended) or pcmci")
     p.add_argument("--pcmci_tau_max", default=1, type=int,
                    help="Max lag for PCMCI (default 2; higher = more stable but slower)")
-    p.add_argument("--pcmci_alpha", default=0.01, type=float,
+    p.add_argument("--pcmci_alpha", default=0.04, type=float,
                    help="Significance level for PCMCI (only affects run_pcmci)")
     p.add_argument("--pcmci_pc_alpha", default=0.01, type=float,
                    help="PC skeleton alpha (0.01 for pcmciplus, None=auto for pcmci)")
@@ -320,8 +320,7 @@ def run_rasl_subject(ts_2d, args, comp_indices, scc_members_override=None,
         edge_weights=priority,
         pnum=args.PNUM,
         optim="optN",
-        selfloop=False,
-        extra_clingo_args=["--opt-heuristic=1"],
+        selfloop=None,
     )
 
     kept = select_top_solutions(

--- a/gunfolds/scripts/real_data/fmri_experiment_large.py
+++ b/gunfolds/scripts/real_data/fmri_experiment_large.py
@@ -59,6 +59,20 @@ DEFAULT_GT_DENSITY_BY_N = {
     53: 13,    # 10–15
 }
 
+# Default PCMCI alpha (run_pcmci significance) per N, when --pcmci_alpha is omitted.
+# Chosen by the PCMCI-only alpha sweep (pcmci_alpha_sweep.py) maximising the
+# Exp 4 composite (0.6·cross-subject Jaccard + 0.4·density proximity to the
+# N-specific GT target). N=20 from the Exp 4 grid; N=10 and N=53 from the
+# 2026-05-27 sweep over 311 FBIRN subjects.
+DEFAULT_PCMCI_ALPHA_BY_N = {
+    10: 0.08,
+    20: 0.05,
+    53: 0.05,
+}
+
+# Fallback alpha for any N not in the table above (e.g. ad-hoc component counts).
+_PCMCI_ALPHA_FALLBACK = 0.05
+
 
 def resolve_fixed_gt_density(n_components: int, explicit: Optional[int]) -> int:
     """
@@ -74,6 +88,19 @@ def resolve_fixed_gt_density(n_components: int, explicit: Optional[int]) -> int:
             "pass --gt_density explicitly."
         )
     return DEFAULT_GT_DENSITY_BY_N[n_components]
+
+
+def resolve_pcmci_alpha(n_components: int, explicit: Optional[float]) -> float:
+    """
+    Return the PCMCI alpha to use.
+
+    If ``explicit`` is None, use the swept default for ``n_components``
+    (DEFAULT_PCMCI_ALPHA_BY_N), falling back to ``_PCMCI_ALPHA_FALLBACK``
+    for component counts not in the table.
+    """
+    if explicit is not None:
+        return explicit
+    return DEFAULT_PCMCI_ALPHA_BY_N.get(n_components, _PCMCI_ALPHA_FALLBACK)
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +157,10 @@ def parse_arguments():
                    help="PCMCI variant: pcmciplus (more stable, recommended) or pcmci")
     p.add_argument("--pcmci_tau_max", default=1, type=int,
                    help="Max lag for PCMCI (default 2; higher = more stable but slower)")
-    p.add_argument("--pcmci_alpha", default=0.04, type=float,
-                   help="Significance level for PCMCI (only affects run_pcmci)")
+    p.add_argument("--pcmci_alpha", default=None, type=float,
+                   help="Significance level for PCMCI run_pcmci. When omitted, "
+                        "uses the swept per-N default (DEFAULT_PCMCI_ALPHA_BY_N: "
+                        "0.08 for N=10, 0.05 for N=20/53).")
     p.add_argument("--pcmci_pc_alpha", default=0.01, type=float,
                    help="PC skeleton alpha (0.01 for pcmciplus, None=auto for pcmci)")
     p.add_argument("--pcmci_fdr", default="none",
@@ -731,6 +760,10 @@ if __name__ == "__main__":
     comp_indices = get_comp_indices(args.n_components)
     comp_names = get_comp_names(comp_indices)
 
+    # Resolve PCMCI alpha from the swept per-N default unless given explicitly.
+    pcmci_alpha_explicit = args.pcmci_alpha is not None
+    args.pcmci_alpha = resolve_pcmci_alpha(args.n_components, args.pcmci_alpha)
+
     print("=" * 80)
     print("FMRI EXPERIMENT CONFIGURATION")
     print("=" * 80)
@@ -763,7 +796,12 @@ if __name__ == "__main__":
         print(f"  PCMCI variant:   {args.pcmci_method}")
         print(f"  PCMCI tau_max:   {args.pcmci_tau_max}")
         if args.pcmci_method == "pcmci":
-            print(f"  PCMCI alpha:     {args.pcmci_alpha}")
+            alpha_src = (
+                "explicit --pcmci_alpha"
+                if pcmci_alpha_explicit
+                else f"swept default for N={args.n_components} (DEFAULT_PCMCI_ALPHA_BY_N)"
+            )
+            print(f"  PCMCI alpha:     {args.pcmci_alpha} ({alpha_src})")
             print(f"  PCMCI FDR:       {args.pcmci_fdr}")
     print("=" * 80)
 

--- a/gunfolds/scripts/tests/benchmark_clingo_configs.py
+++ b/gunfolds/scripts/tests/benchmark_clingo_configs.py
@@ -61,6 +61,7 @@ from gunfolds.scripts.real_data.component_config import (
 CLINGO_LIMIT = 64
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 ALL_CONFIGS = ["frumpy", "jumpy", "tweety", "handy", "crafty", "trendy",
                "auto", "many"]
@@ -390,12 +391,16 @@ def main():
     p.add_argument("--capsize", type=int, default=0)
     p.add_argument("--pcmci_method", default="pcmci")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     p.add_argument("--grounding_interval", type=float, default=5.0)
     p.add_argument("--only", type=str, default="",
                    help="Comma-separated config names to run (e.g. 'crafty,jumpy,trendy')")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     subject_indices = [int(x.strip()) for x in args.subject_idx.split(",")]
     gt_density = args.gt_density

--- a/gunfolds/scripts/tests/benchmark_clingo_flags.py
+++ b/gunfolds/scripts/tests/benchmark_clingo_flags.py
@@ -57,6 +57,7 @@ from gunfolds.scripts.real_data.component_config import (
 CLINGO_LIMIT = 64
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -324,7 +325,9 @@ def main():
                    help="Max models to return (0=unlimited)")
     p.add_argument("--pcmci_method", default="pcmci")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     p.add_argument("--grounding_interval", type=float, default=5.0)
     p.add_argument("--skip", type=str, default="",
@@ -332,6 +335,8 @@ def main():
     p.add_argument("--only", type=str, default="",
                    help="Comma-separated scenario numbers to run (e.g. '1,3,5,7')")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     skip_set = set(int(x) for x in args.skip.split(",") if x.strip())
     only_set = set(int(x) for x in args.only.split(",") if x.strip())

--- a/gunfolds/scripts/tests/benchmark_dedup_fix.py
+++ b/gunfolds/scripts/tests/benchmark_dedup_fix.py
@@ -65,6 +65,7 @@ from gunfolds.scripts.real_data.component_config import (
 CLINGO_LIMIT = 64
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -481,9 +482,13 @@ def main():
     p.add_argument("--capsize", type=int, default=0,
                    help="Max models to return (0 = unlimited)")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     subject_indices = [int(x.strip()) for x in args.subject_idx.split(",")]
     gt_density = (args.gt_density

--- a/gunfolds/scripts/tests/benchmark_density_encoding.py
+++ b/gunfolds/scripts/tests/benchmark_density_encoding.py
@@ -70,6 +70,7 @@ from gunfolds.scripts.real_data.component_config import (
 CLINGO_LIMIT = 64
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -243,6 +244,7 @@ def run_variant(command, variant_label, pnum, capsize, optim, timeout,
         f"--configuration={configuration}",
         "-t", f"{int(pnum)},split",
         "-n", str(capsize),
+        "--stats=2",
     ]
     if extra_clingo_args:
         clingo_args.extend(extra_clingo_args)
@@ -276,6 +278,8 @@ def run_variant(command, variant_label, pnum, capsize, optim, timeout,
     model_count = 0
     best_cost = None
     timed_out = False
+    trajectory = []      # list of (t_elapsed, cost_tuple) for every yielded model
+    improving = []       # subset: only strictly-improving costs
 
     timer = None
     if timeout and timeout > 0:
@@ -297,9 +301,11 @@ def run_variant(command, variant_label, pnum, capsize, optim, timeout,
                 models.append((atoms, cost))
 
                 elapsed = time.time() - t0
+                trajectory.append((elapsed, tuple(cost)))
                 improved = ""
                 if best_cost is None or cost < best_cost:
                     best_cost = cost
+                    improving.append((elapsed, tuple(cost)))
                     improved = " ** NEW BEST **"
 
                 if model_count <= 10 or optimality or improved:
@@ -327,19 +333,56 @@ def run_variant(command, variant_label, pnum, capsize, optim, timeout,
     solve_time   = _sg(times, "solve", 0)
     sat_time     = _sg(times, "sat", 0)
     unsat_time   = _sg(times, "unsat", 0)
-    solver0  = _sg(solvers, 0, _sg(solvers, "0", {}))
-    choices   = _sg(solver0, "choices", 0)
-    conflicts = _sg(solver0, "conflicts", 0)
-    restarts  = _sg(solver0, "restarts", 0)
+    # Aggregate CDCL counters live directly on solving.solvers (clingo 5.7+).
+    # The per-thread breakdown is at solving.solver[i] (singular). The previous
+    # path solving.solvers[0]/["0"] silently returned 0 via _sg's TypeError catch.
+    choices   = _sg(solvers, "choices", 0)
+    conflicts = _sg(solvers, "conflicts", 0)
+    restarts  = _sg(solvers, "restarts", 0)
+    solver_extra    = _sg(solvers, "extra", {})
+    lemmas          = _sg(solver_extra, "lemmas", 0)
+    lemmas_deleted  = _sg(solver_extra, "lemmas_deleted", 0)
+    domain_choices  = _sg(solver_extra, "domain_choices", 0)
+
+    # Trajectory-based phase fingerprint.
+    # Improving = strictly cost-decreasing models. We split wall time into:
+    #   pre_first  : t=0  -> first improving model
+    #   descent    : first improving -> last improving
+    #   proof_tail : last improving -> end of solve
+    t_pre_first = improving[0][0] if improving else None
+    t_last_impr = improving[-1][0] if improving else None
+    t_descent   = (t_last_impr - improving[0][0]) if len(improving) >= 2 else 0.0
+    t_proof     = (t_solve - t_last_impr) if t_last_impr is not None else None
 
     print(f"\n  [RESULT]  solve={t_solve:.2f}s  "
           f"clingo_total={total_time:.2f}s  "
           f"(sat={sat_time:.2f}  unsat={unsat_time:.2f})", flush=True)
     print(f"    models: enumerated={n_enumerated}  optimal={n_optimal}  "
-          f"returned={model_count}", flush=True)
+          f"returned={model_count}  improving={len(improving)}", flush=True)
     print(f"    cost vector: {list(costs)}", flush=True)
     print(f"    choices={choices:,.0f}  conflicts={conflicts:,.0f}  "
-          f"restarts={restarts:,.0f}", flush=True)
+          f"restarts={restarts:,.0f}  lemmas={lemmas:,.0f}  "
+          f"domain_choices={domain_choices:,.0f}", flush=True)
+    # Derived rates (whole-run averages — mid-solve stats unavailable in clingo 5.7).
+    if t_solve > 0:
+        c_per_s = choices / t_solve
+        x_per_s = conflicts / t_solve
+        x_per_c = (conflicts / choices) if choices > 0 else 0.0
+        l_per_x = (lemmas / conflicts) if conflicts > 0 else 0.0
+        print(f"    rates: choices/s={c_per_s:,.0f}  conflicts/s={x_per_s:,.0f}  "
+              f"conflicts/choice={x_per_c:.3f}  lemmas/conflict={l_per_x:.2f}",
+              flush=True)
+    # Phase breakdown.
+    if t_pre_first is not None:
+        f_pre  = t_pre_first / t_solve if t_solve > 0 else 0.0
+        f_desc = t_descent   / t_solve if t_solve > 0 else 0.0
+        f_proof = (t_proof / t_solve) if (t_proof is not None and t_solve > 0) else 0.0
+        proof_str = f"{t_proof:.2f}s ({f_proof:.0%})" if t_proof is not None else "n/a"
+        print(f"    phases: pre_first={t_pre_first:.2f}s ({f_pre:.0%})  "
+              f"descent={t_descent:.2f}s ({f_desc:.0%})  "
+              f"proof_tail={proof_str}", flush=True)
+    else:
+        print(f"    phases: no improving model found within budget", flush=True)
     if timed_out:
         print(f"    *** TIMED OUT — results are best-so-far ***", flush=True)
 
@@ -373,10 +416,19 @@ def run_variant(command, variant_label, pnum, capsize, optim, timeout,
         "n_returned":     model_count,
         "n_enumerated":   int(n_enumerated),
         "n_optimal":      int(n_optimal),
+        "n_improving":    len(improving),
         "best_cost":      list(costs),
         "choices":        int(choices),
         "conflicts":      int(conflicts),
         "restarts":       int(restarts),
+        "lemmas":         int(lemmas),
+        "lemmas_deleted": int(lemmas_deleted),
+        "domain_choices": int(domain_choices),
+        "t_pre_first":    round(t_pre_first, 3) if t_pre_first is not None else None,
+        "t_descent":      round(t_descent, 3),
+        "t_proof":        round(t_proof, 3) if t_proof is not None else None,
+        "trajectory":     [(round(t, 3), list(c)) for t, c in trajectory],
+        "improving":      [(round(t, 3), list(c)) for t, c in improving],
         "ground_atoms":   ground_stats["atoms"],
         "ground_rules":   ground_stats["rules"],
         "ground_minimize": ground_stats["minimize_stmts"],
@@ -427,7 +479,9 @@ def main():
     p.add_argument("--capsize", type=int, default=0)
     p.add_argument("--pcmci_method", default="pcmci")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     p.add_argument("--grounding_interval", type=float, default=5.0)
     p.add_argument("--variants", type=str, default="E,A,C,D",
@@ -440,6 +494,8 @@ def main():
                         "Must be the LAST argument on the command line. "
                         "Example: --extra_clingo_args --opt-strategy=usc,stratify --opt-heuristic=1")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     subject_indices = [int(x.strip()) for x in args.subject_idx.split(",")]
     variants = [v.strip().upper() for v in args.variants.split(",")]
@@ -712,10 +768,11 @@ def main():
         results = all_results[s_idx]
         print(f"\n  Subject {s_idx}:", flush=True)
 
-        header = (f"  {'Variant':<10s} {'Solve(s)':>10s} {'Total(s)':>10s} "
-                  f"{'Models':>8s} {'Optimal':>8s} {'#Sols':>7s} "
-                  f"{'CostVec':>20s} {'Choices':>10s} {'Conflicts':>10s} "
-                  f"{'Minimize':>9s} {'Note':>5s}")
+        header = (f"  {'Variant':<10s} {'Solve(s)':>9s} "
+                  f"{'Pre':>6s} {'Desc':>6s} {'Proof':>6s} "
+                  f"{'#Impr':>6s} {'CostVec':>20s} "
+                  f"{'Choices':>10s} {'Conflicts':>10s} {'C/Ch':>6s} "
+                  f"{'Lemmas':>9s} {'Note':>5s}")
         print(header, flush=True)
         print("  " + "-" * (len(header) - 2), flush=True)
 
@@ -724,17 +781,20 @@ def main():
             if len(cost_str) > 20:
                 cost_str = cost_str[:19] + "~"
             note = "T/O" if r.get("timed_out") else ""
-            n_sol = len(r["solutions"])
+            ts = r["t_solve"] if r["t_solve"] > 0 else 1.0
+            f_pre  = (r["t_pre_first"] / ts) if r.get("t_pre_first") is not None else 0.0
+            f_desc = (r["t_descent"]   / ts) if r.get("t_descent")   is not None else 0.0
+            f_prf  = (r["t_proof"]     / ts) if r.get("t_proof")     is not None else 0.0
+            c_per_ch = (r["conflicts"] / r["choices"]) if r["choices"] > 0 else 0.0
             print(f"  {r['variant_key']:<10s} "
-                  f"{r['t_solve']:>10.2f} "
-                  f"{r['clingo_total']:>10.2f} "
-                  f"{r['n_returned']:>8d} "
-                  f"{r['n_optimal']:>8d} "
-                  f"{n_sol:>7d} "
+                  f"{r['t_solve']:>9.2f} "
+                  f"{f_pre:>5.0%} {f_desc:>5.0%} {f_prf:>5.0%} "
+                  f"{r.get('n_improving', 0):>6d} "
                   f"{cost_str:>20s} "
                   f"{r['choices']:>10,d} "
                   f"{r['conflicts']:>10,d} "
-                  f"{r['ground_minimize']:>9d} "
+                  f"{c_per_ch:>6.2f} "
+                  f"{r.get('lemmas', 0):>9,d} "
                   f"{note:>5s}",
                   flush=True)
 

--- a/gunfolds/scripts/tests/benchmark_domain_heuristic.py
+++ b/gunfolds/scripts/tests/benchmark_domain_heuristic.py
@@ -64,6 +64,7 @@ from gunfolds.scripts.real_data.component_config import (
 CLINGO_LIMIT = 64
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 14: 30, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -379,7 +380,9 @@ def main():
     p.add_argument("--capsize", type=int, default=0)
     p.add_argument("--pcmci_method", default="pcmci")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     p.add_argument("--grounding_interval", type=float, default=5.0)
     p.add_argument("--density_mode", type=str, default="hard_soft0",
@@ -397,6 +400,8 @@ def main():
     p.add_argument("--only", type=str, default="",
                    help="Comma-separated scenario numbers to run (e.g. '0,1')")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     only_set = set(int(x) for x in args.only.split(",") if x.strip())
 

--- a/gunfolds/scripts/tests/diagnose_subject_difficulty.py
+++ b/gunfolds/scripts/tests/diagnose_subject_difficulty.py
@@ -59,6 +59,7 @@ from gunfolds.scripts.real_data.component_config import (
 
 MAXCOST = 20
 DEFAULT_GT_DENSITY_BY_N = {10: 35, 14: 30, 20: 22, 53: 13}
+DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05}  # swept per-N (pcmci_alpha_sweep.py); N not in table -> 0.05
 
 
 def histogram_str(values, bins=10, lo=0, hi=20, width=40):
@@ -202,9 +203,13 @@ def main():
     p.add_argument("--tol_high", type=int, default=5)
     p.add_argument("--pcmci_method", default="pcmci")
     p.add_argument("--pcmci_tau_max", type=int, default=1)
-    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_alpha", type=float, default=None,
+                   help="PCMCI significance level. Omit to use the swept "
+                        "per-N default (DEFAULT_PCMCI_ALPHA_BY_N).")
     p.add_argument("--pcmci_fdr", default="none")
     args = p.parse_args()
+    if args.pcmci_alpha is None:
+        args.pcmci_alpha = DEFAULT_PCMCI_ALPHA_BY_N.get(args.n_components, 0.05)
 
     subject_idxs = [int(x) for x in args.subjects.split(",") if x.strip()]
     gt_density = args.gt_density or DEFAULT_GT_DENSITY_BY_N[args.n_components]

--- a/gunfolds/scripts/tests/diagnose_subject_difficulty.py
+++ b/gunfolds/scripts/tests/diagnose_subject_difficulty.py
@@ -1,0 +1,368 @@
+"""
+Diagnose why some subjects solve much faster than others under the production
+DRASL encoding.
+
+Empirically observed (2026-05-04):
+  N=10, --optim opt, density_mode='hard_soft0', tol_low=15, tol_high=5
+    subject 0: baseline times out (>>1 min, cost still descending past 421)
+    subject 1: baseline solves to proven optimum [608] in 1.43 s
+
+Subject-level features that *should* correlate with solve time:
+
+  1. PCMCI prior sharpness (DD/BD weight distribution).
+     Bimodal at {0, MAXCOST}  -> most edges have an obvious choice -> easy.
+     Concentrated mid-range   -> most edges are ambiguous           -> hard.
+
+  2. Hard density window position.
+     g_estimated density inside [GT-tol_low, GT+tol_high]  -> PCMCI prior
+     is feasible -> solver doesn't fight the cardinality constraint.
+     Outside the window                                    -> harder.
+
+  3. SCC size distribution.
+     Determined by --scc_strategy and which components are picked, *not* by
+     subject data. If --scc_strategy='domain', expected to be identical
+     across subjects at fixed N. Reported for confirmation only.
+
+  4. Cost-landscape flatness.
+     # of distinct DD weight values, std of weights. Flat (many equal weights)
+     means many cost-tied solutions -> enumeration plateau in proof phase.
+
+  5. Edge-count match.
+     Distance between |edges(g_estimated)| and the *centre* of the hard
+     window. Larger distance -> bigger surgery the solver must perform.
+
+Usage:
+  python diagnose_subject_difficulty.py --n_components 10 --subjects 0,1
+  python diagnose_subject_difficulty.py --n_components 14 --subjects 0,1,2,3
+"""
+
+import os
+import sys
+import argparse
+from collections import Counter
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "real_data"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from gunfolds import conversions as cv
+from gunfolds.utils import graphkit as gk
+
+import tigramite.data_processing as pp
+from tigramite.pcmci import PCMCI
+from tigramite.independence_tests.parcorr import ParCorr
+
+from gunfolds.scripts.real_data.component_config import (
+    get_comp_indices, get_scc_members,
+)
+
+MAXCOST = 20
+DEFAULT_GT_DENSITY_BY_N = {10: 35, 14: 30, 20: 22, 53: 13}
+
+
+def histogram_str(values, bins=10, lo=0, hi=20, width=40):
+    """ASCII histogram for a list/array of integers."""
+    if len(values) == 0:
+        return "  (no values)"
+    edges = np.linspace(lo, hi, bins + 1)
+    counts, _ = np.histogram(values, bins=edges)
+    peak = max(counts.max(), 1)
+    out = []
+    for i, c in enumerate(counts):
+        bar = "#" * int(width * c / peak)
+        out.append(f"  [{edges[i]:5.1f}-{edges[i+1]:5.1f}]  "
+                   f"{c:>5d} {bar}")
+    return "\n".join(out)
+
+
+def analyze_subject(subject_idx, data, comp_indices, n_nodes, gt_density,
+                    pcmci_method, pcmci_tau_max, pcmci_alpha, pcmci_fdr,
+                    scc_strategy, tol_low, tol_high):
+    ts_2d = data[subject_idx][:, comp_indices]
+
+    # --- PCMCI ---
+    dataframe = pp.DataFrame(ts_2d)
+    pcmci = PCMCI(dataframe=dataframe, cond_ind_test=ParCorr(), verbosity=0)
+    if pcmci_method == "pcmciplus":
+        results = pcmci.run_pcmciplus(
+            tau_max=pcmci_tau_max, pc_alpha=0.01, fdr_method=pcmci_fdr)
+    else:
+        results = pcmci.run_pcmci(
+            tau_max=pcmci_tau_max, pc_alpha=None,
+            alpha_level=pcmci_alpha, fdr_method=pcmci_fdr)
+    g_estimated, A, B = cv.Glag2CG(results)
+
+    density = gk.density(g_estimated)
+    n_dir = sum(1 for n in g_estimated for t in g_estimated[n]
+                if g_estimated[n][t] in (1, 3))
+    n_bidir = sum(1 for n in g_estimated for t in g_estimated[n]
+                  if g_estimated[n][t] in (2, 3) and n < t)
+
+    # --- DD / BD matrices (same recipe as the benchmark) ---
+    a_max = np.abs(A).max()
+    b_max = np.abs(B).max()
+    if a_max > 0:
+        DD = (np.abs((np.abs(A / a_max) + (cv.graph2adj(g_estimated) - 1))
+                     * MAXCOST)).astype(int)
+    else:
+        DD = (np.abs((cv.graph2adj(g_estimated) - 1) * MAXCOST)).astype(int)
+    if b_max > 0:
+        BD = (np.abs((np.abs(B / b_max) + (cv.graph2badj(g_estimated) - 1))
+                     * MAXCOST)).astype(int)
+    else:
+        BD = (np.abs((cv.graph2badj(g_estimated) - 1) * MAXCOST)).astype(int)
+
+    # Off-diagonal only (self-loops disabled in the encoding)
+    mask = ~np.eye(n_nodes, dtype=bool)
+    DD_off = DD[mask]
+    BD_off = BD[mask]
+
+    # --- Hard density window math ---
+    n_sq = n_nodes * n_nodes
+    d_lo_pct = max(0, gt_density - tol_low)
+    d_hi_pct = min(100, gt_density + tol_high)
+    d_lo_edges = int(d_lo_pct * n_sq / 100)
+    d_hi_edges = int(d_hi_pct * n_sq / 100) + 1
+    cur_edges = n_dir
+    in_window = d_lo_edges <= cur_edges <= d_hi_edges
+    window_centre = (d_lo_edges + d_hi_edges) / 2
+    edges_to_centre = abs(cur_edges - window_centre)
+    feasible_cardinalities = max(0, d_hi_edges - d_lo_edges + 1)
+
+    # --- Sharpness metrics ---
+    # "Sharp" = weights are close to 0 or close to MAXCOST.
+    # ambiguous_count: # of off-diag DD entries strictly between 4 and 16
+    DD_low = int(np.sum(DD_off <= 4))
+    DD_high = int(np.sum(DD_off >= 16))
+    DD_mid = int(np.sum((DD_off > 4) & (DD_off < 16)))
+    sharp_ratio = (DD_low + DD_high) / max(len(DD_off), 1)
+
+    DD_unique = len(np.unique(DD_off))
+
+    # --- SCC structure ---
+    scc_members = get_scc_members(scc_strategy, comp_indices, ts_2d,
+                                  max_cluster_size=8)
+    scc_sizes = sorted([len(s) for s in scc_members],
+                       reverse=True) if scc_members else []
+
+    # --- Total weak-constraint cost we'd see if PCMCI were exactly right ---
+    # Ideal cost: edges PCMCI says present that solver also says present have
+    # cost = DD weight * 0 (matched). So this is a measure of how much
+    # *unavoidable* mismatch the prior implies (irrelevant edges in DD already
+    # contribute 0 if matched).
+    # Simpler proxy: total |DD| over off-diagonal — sum of all edge weights.
+    # Higher  -> more "evidence mass" the solver must shape.
+    total_dd_mass = int(DD_off.sum())
+    total_bd_mass = int(BD_off.sum())
+
+    return {
+        "subject": subject_idx,
+        "density": density,
+        "n_dir": n_dir,
+        "n_bidir": n_bidir,
+        "DD_off": DD_off,
+        "BD_off": BD_off,
+        "DD_min": int(DD_off.min()),
+        "DD_max": int(DD_off.max()),
+        "DD_mean": float(DD_off.mean()),
+        "DD_std": float(DD_off.std()),
+        "DD_low": DD_low,
+        "DD_mid": DD_mid,
+        "DD_high": DD_high,
+        "DD_unique": DD_unique,
+        "sharp_ratio": sharp_ratio,
+        "BD_mean": float(BD_off.mean()),
+        "BD_std": float(BD_off.std()),
+        "scc_sizes": scc_sizes,
+        "n_sq": n_sq,
+        "cur_edges": cur_edges,
+        "d_lo_edges": d_lo_edges,
+        "d_hi_edges": d_hi_edges,
+        "in_window": in_window,
+        "window_centre": window_centre,
+        "edges_to_centre": edges_to_centre,
+        "feasible_cardinalities": feasible_cardinalities,
+        "total_dd_mass": total_dd_mass,
+        "total_bd_mass": total_bd_mass,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--n_components", type=int, default=10,
+                   choices=[10, 14, 20, 53])
+    p.add_argument("--subjects", type=str, default="0,1",
+                   help="Comma-separated subject indices to compare")
+    p.add_argument("--data_path", type=str, default="../fbirn/fbirn_sz_data.npz")
+    p.add_argument("--scc_strategy", type=str, default="domain",
+                   choices=["domain", "correlation", "estimated", "none"])
+    p.add_argument("--gt_density", type=int, default=None)
+    p.add_argument("--tol_low", type=int, default=15)
+    p.add_argument("--tol_high", type=int, default=5)
+    p.add_argument("--pcmci_method", default="pcmci")
+    p.add_argument("--pcmci_tau_max", type=int, default=1)
+    p.add_argument("--pcmci_alpha", type=float, default=0.05)
+    p.add_argument("--pcmci_fdr", default="none")
+    args = p.parse_args()
+
+    subject_idxs = [int(x) for x in args.subjects.split(",") if x.strip()]
+    gt_density = args.gt_density or DEFAULT_GT_DENSITY_BY_N[args.n_components]
+
+    data_path = args.data_path
+    if not os.path.isabs(data_path):
+        data_path = os.path.join(os.path.dirname(__file__), "..", "real_data",
+                                 data_path)
+    npzfile = np.load(data_path)
+    data = npzfile["data"]
+    labels_key = "labels" if "labels" in npzfile.files else "label"
+    labels = npzfile[labels_key]
+
+    comp_indices = get_comp_indices(args.n_components)
+    n_nodes = len(comp_indices)
+
+    print("=" * 80)
+    print(f"SUBJECT-DIFFICULTY DIAGNOSTIC — N={args.n_components}, "
+          f"subjects={subject_idxs}")
+    print("=" * 80)
+    print(f"  GT_density={gt_density}  tol_low={args.tol_low}  "
+          f"tol_high={args.tol_high}")
+    print(f"  Hard window: [{max(0, gt_density-args.tol_low)}%, "
+          f"{min(100, gt_density+args.tol_high)}%] of N²={n_nodes**2}")
+    print()
+
+    results = []
+    for s in subject_idxs:
+        print(f"[Subject {s}, label={int(labels[s])}] running PCMCI...",
+              flush=True)
+        r = analyze_subject(
+            s, data, comp_indices, n_nodes, gt_density,
+            args.pcmci_method, args.pcmci_tau_max,
+            args.pcmci_alpha, args.pcmci_fdr,
+            args.scc_strategy, args.tol_low, args.tol_high)
+        results.append(r)
+
+    # --- Side-by-side table ---
+    print()
+    print("=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+
+    fields = [
+        ("group label",           lambda r, s: int(labels[s])),
+        ("density",               lambda r, _: f"{r['density']:.3f}"),
+        ("# directed edges",      lambda r, _: r['n_dir']),
+        ("# bidirected edges",    lambda r, _: r['n_bidir']),
+        ("",                      None),
+        ("DD min/mean/max",       lambda r, _: f"{r['DD_min']}/"
+                                              f"{r['DD_mean']:.1f}/"
+                                              f"{r['DD_max']}"),
+        ("DD std",                lambda r, _: f"{r['DD_std']:.2f}"),
+        ("DD unique values",      lambda r, _: r['DD_unique']),
+        ("DD low (≤4)",           lambda r, _: r['DD_low']),
+        ("DD mid (5..15)",        lambda r, _: r['DD_mid']),
+        ("DD high (≥16)",         lambda r, _: r['DD_high']),
+        ("Sharp-edge ratio",      lambda r, _: f"{r['sharp_ratio']:.2%}"),
+        ("",                      None),
+        ("Edges in g_est",        lambda r, _: r['cur_edges']),
+        ("Window edge range",     lambda r, _: f"[{r['d_lo_edges']}, "
+                                              f"{r['d_hi_edges']}]"),
+        ("In window?",            lambda r, _: "YES" if r['in_window']
+                                              else "NO"),
+        ("|edges - centre|",      lambda r, _: f"{r['edges_to_centre']:.1f}"),
+        ("Feasible cardinalities",lambda r, _: r['feasible_cardinalities']),
+        ("",                      None),
+        ("SCC sizes",             lambda r, _: r['scc_sizes']),
+        ("",                      None),
+        ("Total DD mass",         lambda r, _: r['total_dd_mass']),
+        ("Total BD mass",         lambda r, _: r['total_bd_mass']),
+    ]
+
+    col_w = max(20, max(len(name) for name, _ in fields))
+    header = f"{'Metric':<{col_w}s} " + " ".join(
+        f"{'subj '+str(r['subject']):>14s}" for r in results)
+    print(header)
+    print("-" * len(header))
+    for name, fn in fields:
+        if fn is None:
+            print()
+            continue
+        row = f"{name:<{col_w}s} " + " ".join(
+            f"{str(fn(r, r['subject'])):>14s}" for r in results)
+        print(row)
+
+    # --- DD weight histograms per subject ---
+    print()
+    print("=" * 80)
+    print("DD WEIGHT HISTOGRAMS (off-diagonal)")
+    print("=" * 80)
+    for r in results:
+        print(f"\nSubject {r['subject']}:  N={len(r['DD_off'])}  "
+              f"mean={r['DD_mean']:.2f}  std={r['DD_std']:.2f}")
+        print(histogram_str(r['DD_off'], bins=10, lo=0, hi=MAXCOST))
+
+    # --- Interpretive narrative ---
+    print()
+    print("=" * 80)
+    print("INTERPRETATION")
+    print("=" * 80)
+
+    if len(results) >= 2:
+        a, b = results[0], results[1]
+        print(f"\nSubject {a['subject']} vs subject {b['subject']}:\n")
+
+        # Sharpness
+        if abs(a['sharp_ratio'] - b['sharp_ratio']) > 0.05:
+            sharper = a if a['sharp_ratio'] > b['sharp_ratio'] else b
+            duller = b if sharper is a else a
+            print(f"  Sharpness: subject {sharper['subject']} has a SHARPER "
+                  f"PCMCI prior ({sharper['sharp_ratio']:.1%} of edges have "
+                  f"DD ≤4 or ≥16, vs {duller['sharp_ratio']:.1%}). "
+                  f"This means the @1 cost objective has fewer ambiguous "
+                  f"middle-ground edges -> typically faster optimum proof.")
+        else:
+            print(f"  Sharpness: similar ({a['sharp_ratio']:.1%} vs "
+                  f"{b['sharp_ratio']:.1%}). Not a likely explanation.")
+
+        # In-window
+        if a['in_window'] != b['in_window']:
+            ins, outs = (a, b) if a['in_window'] else (b, a)
+            print(f"  Density window: subject {ins['subject']} is INSIDE the "
+                  f"hard window (PCMCI prior is feasible by cardinality), "
+                  f"subject {outs['subject']} is OUTSIDE. The outside subject "
+                  f"forces the solver to add/remove edges against the prior.")
+        else:
+            d_a = a['edges_to_centre']
+            d_b = b['edges_to_centre']
+            if abs(d_a - d_b) > 1:
+                closer = a if d_a < d_b else b
+                farther = b if closer is a else a
+                print(f"  Density window: both inside, but subject "
+                      f"{closer['subject']} is closer to centre "
+                      f"({closer['edges_to_centre']:.1f} vs "
+                      f"{farther['edges_to_centre']:.1f} edges away). "
+                      f"Less surgery needed.")
+
+        # Plateau risk
+        if abs(a['DD_unique'] - b['DD_unique']) > 2:
+            flatter = a if a['DD_unique'] < b['DD_unique'] else b
+            sharper2 = b if flatter is a else a
+            print(f"  Cost-tie risk: subject {flatter['subject']} has only "
+                  f"{flatter['DD_unique']} distinct DD weights vs "
+                  f"{sharper2['DD_unique']}. Fewer unique weights -> more "
+                  f"cost-tied solutions -> longer enumeration plateau.")
+
+        # SCC
+        if a['scc_sizes'] != b['scc_sizes']:
+            print(f"  WARNING: SCC sizes differ "
+                  f"({a['scc_sizes']} vs {b['scc_sizes']}) — unexpected "
+                  f"under deterministic --scc_strategy. Check setup.")
+        else:
+            print(f"  SCC structure: identical ({a['scc_sizes']}). "
+                  f"Not an explanation.")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/gunfolds/solvers/clingo_rasl.py
+++ b/gunfolds/solvers/clingo_rasl.py
@@ -421,7 +421,6 @@ def drasl_command(g_list, max_urate=0, weighted=False, scc=False, scc_members=No
         # density_mode == 'hard' adds no soft term.
     if scc:
         command += encode_list_sccs(g_list, scc_members, dm=dm)
-        print("edit this function later to adjust")
     command += f"dagl({len(g_list[0])-1}). "
     command += glist2str(g_list, weighted=weighted, dm=dm, bdm=bdm) + ' '   # generate all graphs
     command += 'uk(1..'+str(max_urate)+').' + ' '

--- a/gunfolds/solvers/clingo_rasl.py
+++ b/gunfolds/solvers/clingo_rasl.py
@@ -420,7 +420,7 @@ def drasl_command(g_list, max_urate=0, weighted=False, scc=False, scc_members=No
             command += f':~ abs_diff(Diff). [Diff*{density_weight}@1] '
         # density_mode == 'hard' adds no soft term.
     if scc:
-        command += encode_list_sccs(g_list, scc_members)
+        command += encode_list_sccs(g_list, scc_members, dm=dm)
         print("edit this function later to adjust")
     command += f"dagl({len(g_list[0])-1}). "
     command += glist2str(g_list, weighted=weighted, dm=dm, bdm=bdm) + ' '   # generate all graphs

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,59 @@ A running list of things to investigate or implement when time allows. Add to th
 
 ## Open
 
+### 7. Bayesian evidence-ratio weights for the SCC quotient MFAS (Option D)
+
+**Where:** `_acyclic_quotient_edges` in `gunfolds/conversions.py`. Currently uses Option C from the design discussion — additive `w(K → L) = pos(K → L) + neg(L → K)` weights with `igraph.Graph.feedback_arc_set(method='exact_ip')`.
+
+**Idea.** Replace the additive weight with a log-likelihood-ratio weight:
+
+```
+w(K → L) = log[ pos(K → L) / pos(L → K) ]
+```
+
+(or a Bayes-factor variant summed across node pairs, or a smoothed version with a small prior to handle the `pos(L → K) = 0` case).
+
+**Why it might be better.** The additive Option C treats the DD weights as additive evidence units; the Bayesian ratio treats them as log-odds. If we ever calibrate DD weights so they're closer to actual log-likelihood-ratios — e.g. by mapping `|partial_correlation_t_statistic|` to a proper p-value-derived score — then Option D becomes the principled choice and Option C becomes a heuristic surrogate.
+
+**Why it's not implemented today.** The current DD recipe `|A_norm| × MAXCOST` is a heuristic transform of partial-correlation magnitudes, not a calibrated probability. Treating these as log-odds without calibration risks distorting the MFAS objective in subtle ways (especially with the `log(0)` degenerate case requiring a small prior). The additive Option C is robust to scaling and works without calibration.
+
+**Action items.**
+
+- Calibrate DD weights against partial-correlation t-statistics (or against a held-out subject's known SCC structure). Validate that the log-ratio form yields meaningful weights.
+- Implement as a `weight_strategy` parameter on `_acyclic_quotient_edges` (`'asymmetry'` for current Option C, `'log_ratio'` for Option D).
+- A/B test on FBIRN N=10 / N=14: does Option D give lower-evidence-cost drops than Option C? Does it change the encoding's optimum cost on real subjects?
+
+**Reference:** logged in chat 2026-05-04 alongside the implementation of Option C. Detailed write-up in `gunfolds/scripts/papers/scc_quotient_edge_dropping_research.md` (local, gitignored).
+
+---
+
+### 6. Suggestion #9 — drop weight-0 `hdirected` / `no_hdirected` (and bidirected) facts at grounding time
+
+**Where:** `glist2str` (or the helper it calls) in `gunfolds/conversions.py`, and any other site that emits `hdirected/no_hdirected/hbidirected/no_hbidirected` facts based on `dm`/`bdm` matrices. Item from §9 of [`gunfolds/scripts/papers/clingo_speedup_suggestions.md`](gunfolds/scripts/papers/clingo_speedup_suggestions.md).
+
+**Idea.** A weak-constraint instance with weight 0 contributes nothing to the cost regardless of whether it's satisfied or violated, but clingo still grounds the rule and tracks it. For node pairs `(X, Y)` where PCMCI has no signal at all (both `DD[X-1, Y-1] == 0` and `BD[X-1, Y-1] == 0`), the four ground facts are dead weight that bloats the program without affecting the objective.
+
+**Conservative version (recommended first step).** Skip emission of all four families for `(X, Y, K)` whenever `dm[K][X-1, Y-1] == 0` AND `bdm[K][X-1, Y-1] == 0`. Zero risk — these facts genuinely contribute nothing.
+
+**Aggressive variants** (each progressively more aggressive, each requires measurement before adopting):
+
+- **#9-A** — also skip an *individual* family when its weight is 0, even if the other family has nonzero weight. E.g. emit only `hbidirected(...)` if `DD = 0` but `BD > 0`.
+- **#9-B** — threshold-based: skip facts with weight `< T` for some cutoff `T` (e.g. 2). Bigger savings, but starts dropping faintly informative constraints; needs a knob to tune.
+
+**Why not done today.** Mostly because we have not actually *measured* whether weight-0 facts are common in our PCMCI output. For FBIRN N=10 with `tau_max=1` and `alpha=0.05`, the DD ranges we have observed are roughly `[4, 20]` and BD `[6, 20]` — no zeros at all in the runs we have looked at. The trick may save 0% on real fMRI runs, in which case it is not worth the implementation. Synthetic / longer-tau runs may behave differently.
+
+**Note about the user's "drop both `hdirected` and `no_hdirected`" recall.** In single-graph mode, only one of `{hdirected(X, Y, W, K), no_hdirected(X, Y, W, K)}` is ever emitted per `(X, Y, K)` — picked by whether `g_estimated[X][Y]` has the directed edge. They are mutually exclusive. Suggestion #9 is *not* about that case; it's about the `DD = BD = 0` case where all four families would carry weight 0. The mutually-exclusive-pair case only arises in multi-graph DRASL where graphs disagree, which we are not currently using.
+
+**Action items.**
+
+- First, *measure*: count how often `DD == 0` AND `BD == 0` per `(X, Y)` pair in production fMRI runs. If never, do not implement.
+- If common enough to matter (say >5% of pairs), implement the conservative version: a one-line guard in `glist2str` that skips both pairs of facts when both DD and BD are 0.
+- Consider the aggressive variants only after seeing what the conservative version saves.
+
+**Reference:** logged in chat 2026-05-04. Tracking item from `clingo_speedup_suggestions.md` §9 bullet 2.
+
+---
+
 ### 5. Checkpoint + warm-restart for long clingo runs that hit timeouts
 
 **Where:** wrapper around the existing solve loop in `gunfolds/scripts/tests/benchmark_domain_heuristic.py` (and any production caller of `drasl()` that has a wall-time budget). Likely lives as a small standalone script `gunfolds/scripts/tests/clingo_with_checkpoint.py` so the checkpoint logic stays orthogonal to other benchmarks.

--- a/todo.md
+++ b/todo.md
@@ -6,41 +6,6 @@ A running list of things to investigate or implement when time allows. Add to th
 
 ## Open
 
-### 1. Investigate the cycle in `dag/3` facts emitted by `encode_list_sccs`
-
-**Where:** `gunfolds/conversions.py` (the `encode_list_sccs` function) → ASP facts emitted into the base command built by `drasl_command`.
-
-**Symptom:** The `dag(K, L, gnum)` facts are supposed to encode an SCC-level DAG (the name says so), but the emitted facts contain cycles. Concrete example observed in a single-subject N=10 run:
-
-```
-dag(0, 2, 1).
-dag(2, 5, 1).
-dag(5, 0, 1).      ← closes a 3-cycle 0 → 2 → 5 → 0
-dag(0, 1, 1).
-dag(5, 1, 1).
-```
-
-If the relation is a true DAG (as the name suggests), this is a bug in `encode_list_sccs`. If it is actually a transitive-closure / reachability relation (and the name is misleading), the constraint logic in `drasl_command` that consumes it still works — but the name should change and the docstring should clarify.
-
-**Why it matters:** the constraint
-
-```clingo
-:- directed(X,Y,U), scc(X,K), scc(Y,L), K != L,
-   sccsize(L,Z), Z > 1, not dag(K,L,N), u(U,N).
-```
-
-uses `not dag(K,L,N)` as a NAF guard. If `dag` is a true DAG, this rule excludes "back-edges" relative to a topological order. If `dag` is reachability, it excludes any cross-SCC edge to a non-reachable SCC. The two semantics give different optimal graphs in some cases.
-
-**Action items:**
-
-- Read `encode_list_sccs` and confirm whether the cycle is intended.
-- If unintended → fix the function and re-benchmark on FBIRN N=10 to confirm cost numbers don't shift.
-- If intended → rename the relation (e.g. `scc_reach/3`) or at minimum add a docstring/comment in both `encode_list_sccs` and the `drasl_command` rule that consumes it.
-
-**Reference:** noticed during the N=10 / `selfloop=None` benchmark on 2026-04-28 while reviewing the base ASP command for subject 0.
-
----
-
 ### 2. Why does clingo report `choices = 0`, `conflicts = 0`, `restarts = 0` in every run?
 
 **Where:** `gunfolds/scripts/tests/benchmark_density_encoding.py` (the `_sg(...)` stats extraction in `run_variant`), and any other script that reads `ctrl.statistics["solving"]["solvers"]…`.
@@ -95,4 +60,70 @@ The current code does `_sg(solvers, 0, _sg(solvers, "0", {}))` then reads `.choi
 
 ## Done
 
-*(nothing yet)*
+### 1. Investigate the cycle in `dag/3` facts emitted by `encode_list_sccs` — **resolved 2026-05-04: rename + acyclic-quotient via back-edge dropping**
+
+**Root cause.** `encode_sccs` (in `gunfolds/conversions.py`) calls
+`networkx.algorithms.components.condensation(G, scc=SCCS)`. NetworkX's
+`condensation` requires `scc` to be a *partition* of the nodes, but does
+**not** enforce that the elements are actually strongly connected. When
+`scc_members` comes from `--scc_strategy=domain` / `correlation`, the
+partition may *split* a real SCC across multiple classes, and the
+"condensation" is a generic quotient digraph with cycles — making the SCC
+integrity constraints reject some valid cross-class arrows and accept some
+invalid ones.
+
+**Design decision: drop back-edges, keep all classes.** Two ways to make the
+quotient acyclic:
+
+1. **Merge** any classes that lie in the same SCC of the quotient
+   (theoretically sound; restores a true SCC coarsening).
+2. **Drop back-edges** within each cyclic SCC of the quotient (technically
+   unsound — may reject valid arrows in dropped directions — but preserves
+   the user's intended class granularity).
+
+Approach (1) collapses the 7-class NeuroMark domain partition to a single
+SCC on real fMRI data because every domain pair has bidirectional flow at
+PCMCI alpha=0.05; the constraint then becomes vacuous and all SCC pruning
+power is lost. The user explicitly chose approach (2) to preserve per-class
+pruning and keep per-SCC decomposition meaningful as a future speedup.
+
+**Fix applied.**
+
+1. Renamed predicate `dag/3` → `scc_edge/3` (3 sites in
+   `gunfolds/conversions.py`).
+2. Added new helper `_acyclic_quotient_edges(glist, partition)` — builds
+   the quotient over the union of `glist`, finds its SCCs, picks a
+   deterministic within-SCC class order (sorted by class index), and
+   filters edges so only forward arrows survive. Returns
+   `(triples, n_dropped)`.
+3. Added a `quotient_edges` override parameter to `encode_sccs` so callers
+   can bypass `condensation` and emit a precomputed acyclic edge set.
+4. `encode_list_sccs` now precomputes the acyclic edges via the helper and
+   passes per-graph slices to `encode_sccs`; prints a one-line stdout
+   report when back-edges are actually dropped.
+5. Docstrings updated on all three functions.
+6. `gunfolds/scripts/papers/example_clingo.md` updated to match the
+   emitter.
+
+**Empirical verification.**
+
+| Test | Input | Output |
+|---|---|---|
+| Synthetic | partition `[{1}, {2,3}, {4}]` over `1→2, 2→3, 3→1, 4→3` | preserved 3 classes; dropped 1 back-edge; `scc_edge` acyclic |
+| Real fMRI subject 0 N=10 | domain partition `[{1,2}, {3}, {4}, {5}, {6,7}, {8,9}, {10}]` | preserved 7 classes; dropped 14 back-edges; 8 forward `scc_edge` facts; acyclic |
+| Real fMRI subject 1 N=10 baseline | `--optim opt` | **0.03 s** to optimum `[452, 350]` (was 1.43 s for `[340, 350]` under unsound cyclic encoding) |
+
+The new optimum (452) is *higher* than the prior 340 because the new
+encoding is more restrictive: cycles in the old quotient allowed cross-class
+arrows that should have been forbidden, so the prior 340 was a phantom
+optimum produced by an unsound encoding. **All prior fMRI optimization
+numbers measured against `--scc_strategy=domain` should be regenerated
+before being cited.**
+
+**Future work.** Per-SCC decomposition (solve each class's sub-problem
+independently in Python, then combine) is now meaningful since the
+partition is preserved. Not implemented in this change.
+
+**Out-of-scope finding (separate cleanup):** `clingo_rasl.py:425` emits a
+`dagl(N-1)` fact that is never consumed by any rule in the project — pure
+dead code. Should be deleted in a separate change.

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,172 @@ A running list of things to investigate or implement when time allows. Add to th
 
 ## Open
 
+### 5. Checkpoint + warm-restart for long clingo runs that hit timeouts
+
+**Where:** wrapper around the existing solve loop in `gunfolds/scripts/tests/benchmark_domain_heuristic.py` (and any production caller of `drasl()` that has a wall-time budget). Likely lives as a small standalone script `gunfolds/scripts/tests/clingo_with_checkpoint.py` so the checkpoint logic stays orthogonal to other benchmarks.
+
+**Idea.** When a clingo solve hits a timeout (or a cluster preemption), we currently throw away the best incumbent and the next attempt starts from cost ∞. The descent through high-cost models took ~50–60 s on N=14 subject 1 (out of an 800 s budget that timed out without proving optimum). Save the incumbent on every new best, and on resume start a fresh clingo session that knows the previous best as an upper bound. Standard "warm-restart" pattern from MaxSAT competition.
+
+**Two ingredients (clasp supports both natively).**
+
+1. **Cost upper bound** — pass `--opt-bound=C` (or per-priority `--opt-bound=C1,C2` for the `[edge@1, density@0]` vector). Clasp prunes any partial assignment whose lower bound exceeds it. **One scalar per priority level, no model state needed.** Always safe.
+2. **Branching seed** (optional, opt-in) — emit `#heuristic edge1(X,Y). [W,true|false]` directives derived from the incumbent atoms, run clasp with `--heuristic=Domain`. The first model in the resumed session typically lands at or near the previous incumbent in the first few decisions.
+
+The cost-bound part alone (#1) is the unambiguous win and should be the default. The branching seed (#2) is the same mechanism rejected as suggestion #4 — but used here from a *known feasible incumbent* rather than the noisy PCMCI prior, which is qualitatively different. Worth re-testing as an opt-in flag, with the awareness that it could re-introduce the "biases backtracking, hurts proof" failure mode in a different costume.
+
+**What is NOT possible.** Clasp does not serialize internal solver state — clause database, conflict trail, restart phase, VSIDS scores. Each new `Control()` is a fresh search. "Resume from checkpoint" really means "warm-start hint to a fresh search," not "pick up where you left off." This means the proof-phase budget after warm restart is a fresh budget (not cumulative). The win is purely on the descent: skip the time spent finding any model worse than the incumbent.
+
+**Hard guard rails.**
+
+- **Never include the incumbent's edges as hard constraints** (`:- not edge1(X,Y).` for each true edge). If the true optimum requires removing one of those edges, you have made it unreachable and silently sub-optimal. Hard-pinning is a tempting shortcut and breaks soundness — only use the soft Domain heuristic.
+- The cost bound must be passed correctly for the *full* priority vector. Passing `--opt-bound=778` when the cost is `[778, 350]` is ambiguous and may be interpreted as a single-priority bound. Always pass the comma-separated form matching the vector length.
+- Atomic checkpoint writes (write to `checkpoint.json.tmp`, then `os.replace`) so a SIGTERM mid-write doesn't corrupt the file.
+
+**Design sketch.**
+
+```
+class CheckpointWriter:
+    def __init__(self, path):
+        self.path = path
+        self.best_cost = None
+    def maybe_save(self, cost, atoms):
+        if self.best_cost is None or cost < self.best_cost:
+            tmp = self.path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump({"cost": list(cost), "atoms": atoms,
+                           "ts": time.time()}, f)
+            os.replace(tmp, self.path)
+            self.best_cost = cost
+
+# In the solve loop:
+ckpt = CheckpointWriter(args.checkpoint_path)
+for model in handle:
+    cost = list(model.cost)
+    atoms = [str(a) for a in model.symbols(shown=True)]
+    ckpt.maybe_save(cost, atoms)
+
+# On resume:
+def resume_args(checkpoint_path, with_heuristic_seed=False):
+    data = json.load(open(checkpoint_path))
+    cost = data["cost"]
+    bound = ",".join(str(c - 1) for c in cost)   # strict improvement
+    extra = [f"--opt-bound={bound}"]
+    program_addendum = ""
+    if with_heuristic_seed:
+        extra.append("--heuristic=Domain")
+        true_edges = parse_edge1_atoms(data["atoms"])
+        program_addendum = build_heuristic_block_from_incumbent(
+            true_edges, n_nodes)
+    return extra, program_addendum
+```
+
+**CLI flags to add to a new `clingo_with_checkpoint.py`.**
+
+- `--checkpoint_path PATH` (default `<output_dir>/checkpoint.json`)
+- `--resume_from PATH` — read cost + atoms, set `--opt-bound`, optionally seed.
+- `--warm_seed_from_checkpoint` (flag, default off) — also emit Domain-heuristic seed from the incumbent atoms.
+- `--auto_resume_chain N` — run N consecutive sessions of `--timeout` each, automatically chaining checkpoint between them. Useful for cluster jobs with strict per-job time limits.
+
+**Open design questions to resolve when implementing.**
+
+- **Per-priority bound semantics.** `--opt-bound=778,349` enforces strict improvement on edge cost AND on density. Sometimes desirable (force progress on both axes), sometimes not (we want to keep density and just improve edge cost). Reasonable default: pass the bound from the previous best with `-1` only on the highest priority (`@1`), keep `@0` at the previous value (allow same density). Worth measuring both.
+- **Where to store checkpoints in production.** Same directory as benchmark logs is fine for one-off experiments. For SLURM jobs, the SCRATCH dir convention. Should match whatever pattern existing `fmri_experiment_large.py` already uses.
+- **Should `drasl()` itself learn to write checkpoints, or only the orchestration layer?** Lean toward orchestration only — `drasl_command` should stay a pure encoding builder, and checkpointing is solver-loop concern.
+
+**Action items.**
+
+1. Implement cost-bound-only first as a standalone script. Measure on N=14 subject 1: does a 200 s session followed by a 200 s warm-resume reach a better incumbent than a single 400 s fresh session?
+2. If (1) shows a win, add the optional Domain-heuristic seed as a flag. A/B test whether seeding helps further or re-introduces the suggestion #4 failure pattern.
+3. If both win, integrate with the SLURM job scripts so cluster preemption automatically chains checkpoints.
+
+**Reference:** raised in chat 2026-05-04 after the GPU-acceleration discussion.
+
+---
+
+### 4. GPU acceleration of the clingo optimization — revisit when GPU SAT/MaxSAT tooling matures
+
+**Where:** the clingo solving step inside `drasl()` / `drasl_command` (currently parallelised via clasp's `-t N,split` or `-t N,compete` across CPU threads).
+
+**Question.** Today clingo runs on CPUs. A single subject at N=14 already pegs ~10 cores for tens of seconds with diminishing returns past ~16 threads. Could we plug in a GPU somewhere to get the kind of 10–100× wall-time win that GPUs deliver for, e.g., neural network training?
+
+**Current assessment (2026-05-04): no clear path with present-day tooling, revisit later.**
+
+The hot loop inside clasp is CDCL — Conflict-Driven Clause Learning. Each step is: pick a branching variable, propagate via watched literals (pointer-chasing through linked lists), on conflict analyse and learn a clause, backtrack to the right level, repeat. Per-step work is tiny, memory access is highly irregular, and every step depends on the previous one. The `-t N,split` / `compete` modes are *coarse-grained* parallelism: each thread runs an independent CDCL solver and they share learned clauses. They do not parallelise the per-step work.
+
+GPUs need (a) regular memory access, (b) high arithmetic intensity, (c) the same operation over millions of elements. CDCL is the opposite on all three axes. Branch divergence inside a warp would be near-total. A small academic literature exists on GPU SAT solvers (e.g. *clauSPaR*, *ParaFROST-GPU*); they generally lose to a single modern CPU solver on industrial benchmarks. Running 10 000 GPU-resident solvers in portfolio mode tends to net out as 10 000 solvers each at 1/1000th of CPU speed.
+
+**What this argument does NOT cover (and why it's worth revisiting later).**
+
+- The argument applies to *complete* CDCL/Branch-and-Bound. *Incomplete* GPU MaxSAT solvers based on parallel local search (simulated annealing, parallel tempering) are an active research area and could in principle scale. They would not produce optimality proofs but might match clingo's "best feasible" within seconds.
+- NVIDIA's *cuOpt* (GPU-accelerated optimisation, currently focused on routing/ILP) keeps adding solver families. If they ever add weighted MaxSAT or pseudo-boolean optimisation, plugging it in becomes worth measuring.
+- Tensor-network / GBP-style approaches to constraint satisfaction map naturally to GPUs and have shown promise on structured problems. The DRASL encoding is highly structured (per-undersampling, per-SCC), so it could be a good candidate.
+- Quantum-inspired annealers (D-Wave, Fujitsu Digital Annealer, NEC SX-Aurora) are a separate hardware path; they target QUBO and weighted MaxSAT directly. Worth re-evaluating every 12–18 months.
+
+**What we *would* implement first if GPU acceleration ever made sense.**
+
+- **GPU PCMCI.** Partial correlation tests are dense linear algebra and well-suited to GPUs. This is independent of the clingo question and would speed up the whole pipeline; trivial to prototype with `cupy`.
+- **GPU brute-force as an oracle for small N (N ≤ 6).** A CUDA kernel could enumerate all `2^(N²)` candidate edge sets in minutes and serve as ground truth for verifying the clingo solver. Useful for correctness validation, not a production solver.
+
+**What we should NOT do.**
+
+- Port CDCL to CUDA. Would take weeks and produce a slower solver.
+- Switch to a GPU-only ILP encoding without measuring against the existing CPU clingo first.
+
+**Higher-priority alternatives that should land first.**
+
+- **Per-SCC Python decomposition** (item 3 below). Expected 10–100× wall-time win on N≥14, ≈1–2 days of engineering. This dominates anything GPU work could plausibly deliver and should be done before any GPU exploration.
+- **Cluster job parallelism.** One subject per cluster node with `-t 64,compete` gives linear scaling across subjects with no code change.
+- **Tighter density tolerance** (`tol_low=8, tol_high=3`). Cheap configuration tweak that prunes the cardinality search by ~2–5× on hard subjects.
+
+**Action items.**
+
+- Re-evaluate this entry every ~18 months or whenever a credible GPU MaxSAT / weighted-PB solver ships (NVIDIA cuOpt updates, academic releases, etc.).
+- Before spending serious time on a GPU port, confirm that per-SCC decomposition (item 3) and density-tolerance tuning are already in production.
+- If a candidate GPU solver appears, validate first on the small-N brute-force oracle to make sure it returns the same optimum as clingo.
+
+**Reference:** raised in chat 2026-05-04 after delivering the SCC encoding fix on branch `scc-edge-acyclic-quotient`.
+
+---
+
+### 3. Per-SCC Python-level decomposition of the DRASL optimization
+
+**Where:** Orchestration layer above `drasl_command` / `drasl` in `gunfolds/solvers/clingo_rasl.py`, plus the existing SCC-aware encoding in `gunfolds/conversions.py` (where `_acyclic_quotient_edges` already preserves the partition).
+
+**Idea.** Once the user-supplied SCC partition is preserved as distinct classes (delivered in commit `0079ca60` on branch `scc-edge-acyclic-quotient`), we can split the global optimization into one independent sub-problem per SCC and solve them in parallel. Each sub-problem is exponentially smaller in the candidate-edge space, so the combined wall time should drop by another order of magnitude beyond the in-encoding pruning win we already measured (47× on N=10 subject 1).
+
+**Decomposition sketch.**
+
+1. Split nodes by SCC class: ``n_classes`` sub-problems, each over the nodes inside one class.
+2. Build a per-class measurement view: restrict ``g_estimated``, ``DD``, and ``BD`` to the rows/columns of nodes inside the class.
+3. Solve each per-class DRASL instance independently (parallel processes / threads), each finds its own optimum causal sub-graph.
+4. Merge: the combined causal graph is the union of within-class edges from each sub-problem plus the *forward* cross-class edges that are witnessed in `scc_edge` (these are determined by the DAG order, not optimization variables).
+
+**Open design questions.**
+
+- **Cross-SCC `hdirected` / `hbidirected` weights.** Each one is a measurement-scale fact about a pair (X, Y) where X and Y can be in different classes. Naively, this couples two sub-problems. Options: (a) treat cross-class measurement weights as a separate small post-processing step that decides whether to include each cross-class edge, given the within-class solutions; (b) include them as boundary constraints in both sub-problems and re-solve if they disagree; (c) ignore them inside sub-problems and recover them from the post-merge graph using the existing `bfutils.undersample` machinery. Option (a) is cleanest if the DAG-order constraint already determines most cross-class edges.
+
+- **Undersampling closure across classes.** The encoding's `directed(X, Y, L)` rule chains length-L paths through *any* nodes — including nodes in different classes. Splitting by class breaks this chain. Probably fine for within-class subproblems (they only enumerate paths through their own nodes) but cross-class paths need separate handling. Verify on a small N=10 case.
+
+- **Density window decomposition.** The hard `[GT-tol_low, GT+tol_high]` cardinality constraint is over the *whole* graph. We need either a per-class proportional sub-budget or a single post-merge feasibility check. Per-class proportional is simpler but may over-constrain on uneven class sizes.
+
+- **`MAXU` and `u/2` choice.** The undersampling rate is a single global decision. Either fix it across all sub-problems (probably what we want) or treat it as a top-level loop with K sub-problems per u-value.
+
+**Why it matters.**
+
+- Per-SCC independence is a structural decomposition that VSIDS / clasp branching cannot exploit on its own — it requires Python-side orchestration.
+- If each sub-problem is small enough (say, ≤4 nodes per SCC at N=14), each one solves in well under a second even with `optN`. Combined wall time stays bounded as N grows, instead of exponential.
+- This is the single biggest speedup lever we have not yet pulled. It complements (not replaces) all the encoding-level fixes.
+
+**Action items.**
+
+- Prototype on a 2-SCC synthetic case first (e.g. two disjoint 5-node graphs joined by one cross-edge) to validate the decomposition recovers the same optimum as the monolithic solve.
+- Then apply to N=14 fMRI subject 1 (same subject we benchmarked, where SCC pruning now actually fires) and compare wall time and optimum cost vs. the monolithic baseline.
+- If validated, add a `decompose_by_scc=True` flag to `drasl()` and benchmark across N=10/14/20.
+
+**Reference:** spun out from chat 2026-05-04 ("Reading 2: Python-level decomposition") after delivering the in-encoding SCC fix on branch `scc-edge-acyclic-quotient`.
+
+---
+
 ### 2. Why does clingo report `choices = 0`, `conflicts = 0`, `restarts = 0` in every run?
 
 **Where:** `gunfolds/scripts/tests/benchmark_density_encoding.py` (the `_sg(...)` stats extraction in `run_variant`), and any other script that reads `ctrl.statistics["solving"]["solvers"]…`.

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,26 @@ A running list of things to investigate or implement when time allows. Add to th
 
 ## Open
 
+### 8. Re-run the H-frequency test experiment with the new bug fixes and recreate the paper figure
+
+**What:** Re-run the experiment that produced the H-frequency test figure in the paper, now with two bugs fixed that silently corrupted the simulation pipeline:
+
+1. **`end_time` scaling bug** (`simulate_bold` must pass `end_time=100 * u_rate` — checklist item 16). Without this fix, the BOLD signal before and after undersampling was identical regardless of `u_rate`, meaning the experiment was effectively testing `u_rate=1` for all conditions.
+2. **`gk.randomDAG` infinite-loop workaround** (`randomDAG` bypassed for ≤2 SCC quotient nodes — checklist item 17). This was a hang, not a silent data corruption, so it likely did not affect figures that completed — but verify.
+
+**Why:** If any figure was produced using the uncorrected `simulate_bold` (without `end_time` scaling), the simulated fMRI data was not actually undersampled — the ground-truth / observed mismatch used to benchmark H-frequency recovery was wrong. The corrected pipeline may produce materially different recovery curves.
+
+**Action items:**
+
+1. Identify the exact script and commit used to generate the H-frequency figure. Check whether `compute_bold_signals` was called with or without `end_time=100*u_rate`.
+2. If the bug was present, re-run with the corrected `simulate_bold` and compare the new curves to the published ones. Document any differences.
+3. Regenerate the figure and update the paper draft accordingly.
+4. If the figures are unchanged (bug was absent in that script), note it here and close.
+
+**Reference:** bugs found 2026-05-04 during `runtime_scaling.py` local test run; documented in checklist items 16 and 17.
+
+---
+
 ### 7. Bayesian evidence-ratio weights for the SCC quotient MFAS (Option D)
 
 **Where:** `_acyclic_quotient_edges` in `gunfolds/conversions.py`. Currently uses Option C from the design discussion — additive `w(K → L) = pos(K → L) + neg(L → K)` weights with `igraph.Graph.feedback_arc_set(method='exact_ip')`.

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,48 @@ A running list of things to investigate or implement when time allows. Add to th
 
 ## Open
 
+### 9. Per-subject solution selection + parallel U-rate sweep + N=20 ICA run (NEXT)
+
+**The immediate next thing to do.** Three coupled pieces:
+
+1. **Per-subject solution retention.** For each subject, decide *which* clingo
+   solutions to keep for downstream analysis rather than collapsing to a single
+   point estimate. Open questions: keep only the cost-optimal model, or the
+   top-k within a delta of the optimum? Keep one-per-U-rate, or pool across U?
+   How do we represent/store the retained set so later analysis (group stats,
+   stability across subjects) can consume it? Define the selection rule
+   explicitly before scaling up.
+
+2. **Parallel U-rate sweep.** Split the clingo runs by undersampling rate so
+   different U values run in parallel (one process / cluster task per U),
+   instead of looping U sequentially inside one solve. Then merge: keep the
+   best solution(s) per U and decide how to combine across U for a subject
+   (ties to piece 1's retention rule). *Think through how:* job fan-out
+   (SLURM array over U), result collection, and the comparison that picks the
+   winner(s). Watch the cost-vector comparability across different U (is
+   `[edge@1, density@0]` directly comparable between U rates, or does the
+   density target shift per U?).
+
+3. **Run for 20 ICA components.** Execute the full pipeline at N=20. Re-derive
+   the best-20 ICA component selection from scratch — do **not** assume the
+   N=10 picks are a subset; re-run the component-ranking step and confirm the
+   chosen 20 are the right ones for this analysis. N=20 default PCMCI alpha is
+   already wired (0.05, `DEFAULT_PCMCI_ALPHA_BY_N`).
+
+**Action items.**
+
+- Decide and write down the per-subject solution-retention rule (top-k vs.
+  optimal-only; per-U vs. pooled).
+- Build the parallel U-rate fan-out (SLURM array or process pool), with a
+  collector that keeps best-per-U and applies the retention rule.
+- Re-run the best-20 ICA component selection; verify the picks.
+- Run the N=20 pipeline end-to-end with the parallel U sweep and retained
+  solutions.
+
+**Reference:** logged 2026-05-28.
+
+---
+
 ### 8. Re-run the H-frequency test experiment with the new bug fixes and recreate the paper figure
 
 **What:** Re-run the experiment that produced the H-frequency test figure in the paper, now with two bugs fixed that silently corrupted the simulation pipeline:
@@ -245,59 +287,35 @@ GPUs need (a) regular memory access, (b) high arithmetic intensity, (c) the same
 
 ---
 
-### 2. Why does clingo report `choices = 0`, `conflicts = 0`, `restarts = 0` in every run?
+## Done
 
-**Where:** `gunfolds/scripts/tests/benchmark_density_encoding.py` (the `_sg(...)` stats extraction in `run_variant`), and any other script that reads `ctrl.statistics["solving"]["solvers"]…`.
+### 2. Clingo `choices/conflicts/restarts` always 0 — **resolved 2026-05-28: wrong stats path + new phase fingerprint**
 
-**Symptom:** Every single benchmark run prints `choices=0  conflicts=0  restarts=0`, even when the solver clearly did substantial work (35+ improving models found, optimality proven, etc.). These are core CDCL solver counters — seeing zero is impossible if solving happened.
+**Root cause.** `run_variant` read `_sg(solvers, 0, _sg(solvers, "0", {}))`. In clingo 5.7.1 the stats tree puts the *aggregate* CDCL counters directly on `solving.solvers.{choices,conflicts,restarts}`, and the *per-thread* breakdown on `solving.solver[i]` (singular `solver`, an array). Both `solvers[0]` (int key → `TypeError`) and `solvers["0"]` (missing key → `KeyError`) were silently swallowed by `_sg`, returning the `0` default. So the solver was always working fine — purely a reporting glitch, not a correctness bug. All prior costs/timings stand; only the printed counters were wrong.
 
-**Hypothesis:** The stats extraction path is wrong for multi-threaded runs. With `-t {pnum},split`, clasp arranges the stats tree as:
+**Fix.** Read `solving.solvers.{choices,conflicts,restarts}` directly; also pull `extra.{lemmas,lemmas_deleted,domain_choices}`. Added `--stats=2` so the `extra` subtree populates. Added a trajectory-based **phase fingerprint**: record `(t, cost)` per yielded model, split wall time into `pre_first / descent / proof_tail`, and print derived rates (`choices/s`, `conflicts/s`, `conflicts/choice`, `lemmas/conflict`). New result-dict fields + new summary-table columns. **Files:** `gunfolds/scripts/tests/benchmark_density_encoding.py`.
 
-```
-solving:
-  solvers:
-    choices:    <aggregate sum across threads>
-    conflicts:  <aggregate>
-    restarts:   <aggregate>
-    0:                       ← per-thread node
-      choices: ...
-      ...
-    1: { ... }
-    ...
-```
+**What the fixed counters revealed (FBIRN N=10 subject 0, variant C):**
 
-The current code does `_sg(solvers, 0, _sg(solvers, "0", {}))` then reads `.choices` from that — likely throwing an exception silently caught by `_sg`, returning the `0` default. The aggregate counters at `solving.solvers.choices` (one level up from the per-thread node) are probably what we want.
+| Strategy | Threads | Solve | Proof tail | Conflicts | Optimum |
+|---|---|---|---|---|---|
+| `bb,lin` (default) | 10 | **2.0 s** | 70 % | 390 K | `[178,400]` |
+| `bb,lin` (default) | 1 | 3.2 s | 78 % | 179 K | `[178,400]` |
+| `bb,hier` | 10 | 2.6 s | 90 % | 517 K | `[178,400]` |
+| `bb,dec` | 10 | 4.3 s | 92 % | 1.23 M | `[178,400]` |
+| `usc,oll` | 10 (forced compete) | **120 s T/O** | — | 8.07 M | none `[inf,inf]` |
+| `usc,oll` | 1 | **45 s T/O** | — | 476 K | none `[inf,inf]` |
 
-**Why it matters:**
+**Conclusions.**
 
-- Without correct counters we cannot empirically attribute speed differences between variants A/C/D/E to grounding size vs search-tree size vs conflict learning.
-- USC's failure mode (high conflicts, slow bound improvement) is invisible.
-- Plateau-enumeration cost (many choices, ~0 conflicts) is invisible.
-- Any future paper claiming "X is faster because Y" needs these numbers to back it up.
+1. **Solver-strategy axis is exhausted.** Default `bb,lin` wins; every alternative is slower or broken. The ~70–90 % proof tail is *intrinsic* to the instance (cost of proving no graph beats edge-cost 178) — no clasp flag shrinks it.
+2. **USC re-confirmed dead, now with the mechanism visible.** The counter fix exposed exactly the failure this item predicted ("USC's failure mode = high conflicts, slow bound improvement, invisible"): 8 M conflicts, **0** bound improvement, no feasible model — at both 10-thread and single-thread, so it is *not* a compete-mode artifact. Mechanism: core-guided USC peels weighted cores worth the full optimum (178 units at `MAXCOST=20`) and never constructs a feasible model. Joins the prior USC rejection (2026-04-13, `clingo_clasp_optimization_flags_benchmark.md`).
+3. **The phase fingerprint is a branch-and-bound instrument.** Core-guided search emits no streaming improving models by design, so the trajectory/fingerprint goes blind under USC (`improving=0` is partly inherent, not just failure).
+4. **N=10 is too small to optimize** (2–3 s total). The fingerprint's real job is the N=14/20 runs that hit 800 s timeouts. The proof-vs-descent balance there decides the lever: if **proof dominates** → encoding-level (item #6 drop weight-0 facts, item #7 weight calibration shrink the core to be proven); if **descent dominates** → structural (item #3 per-SCC decomposition). Either way, **not** solver flags.
 
-**Action items:**
-
-- Dump the full stats tree from one run to see where choices/conflicts actually live:
-  ```python
-  import json
-  def _dump(s):
-      if hasattr(s, "keys"):
-          return {k: _dump(s[k]) for k in s.keys()}
-      if hasattr(s, "__len__") and not isinstance(s, str):
-          try: return [_dump(s[i]) for i in range(len(s))]
-          except Exception: return str(s)
-      return s
-  print(json.dumps(_dump(ctrl.statistics), indent=2)[:5000])
-  ```
-- Replace the per-thread lookup with the aggregate path: `solvers.choices`, `solvers.conflicts`, `solvers.restarts`.
-- Optionally also report per-thread breakdown by iterating numeric keys under `solvers`.
-- Re-run the existing benchmarks once fixed and back-fill the proper numbers in `gunfolds/scripts/papers/clingo_drasl_encoding_improvements.md`.
-
-**Reference:** flagged in the analytical review of the 10-subject Variant E run (2026-04-27) — explicitly noted as "unfixed" in §4.7 of the encoding-improvements paper.
+**Reference:** flagged in the 10-subject Variant E review (2026-04-27), §4.7 of the encoding-improvements paper. Diagnosed and fixed 2026-05-28.
 
 ---
-
-## Done
 
 ### 1. Investigate the cycle in `dag/3` facts emitted by `encode_list_sccs` — **resolved 2026-05-04: rename + acyclic-quotient via back-edge dropping**
 


### PR DESCRIPTION
Summary
This branch makes the SCC-aware DRASL encoding sound (the headline fix), wires up per-N PCMCI alpha defaults, adds a runtime-scaling experiment harness, and fixes a clingo stats-reporting bug. ~3,000 lines added across encoding, experiment scripts, and diagnostics.

Core fix — acyclic SCC quotient (soundness)
gunfolds/conversions.py, gunfolds/solvers/clingo_rasl.py

Renamed the dag/3 predicate to scc_edge/3 and reworked how the SCC quotient is built. NetworkX condensation was being handed a partition that wasn't guaranteed strongly connected (from --scc_strategy=domain/correlation), producing a cyclic quotient that silently rejected valid cross-class arrows and accepted invalid ones.
New _acyclic_quotient_edges(glist, partition) helper builds the quotient, finds its SCCs, and drops back-edges via a weighted minimum feedback-arc-set (igraph feedback_arc_set(method='exact_ip')), preserving the user's class granularity instead of collapsing classes.
Consequence: optimization costs under --scc_strategy=domain are now higher than before because the old encoding was unsound — prior fMRI optima against the domain partition were phantoms and should be regenerated before citing.
PCMCI alpha per-N defaults
fmri_experiment_large.py + benchmark_{clingo_configs,clingo_flags,dedup_fix,density_encoding,domain_heuristic}.py, diagnose_subject_difficulty.py

Added DEFAULT_PCMCI_ALPHA_BY_N = {10: 0.08, 20: 0.05, 53: 0.05} (fallback 0.05), derived from a PCMCI-only alpha sweep maximizing the Exp-4 composite (cross-subject Jaccard + density proximity to the per-N target).
--pcmci_alpha now defaults to None and auto-resolves per --n_components; explicit values still override. Mirrors the existing DEFAULT_GT_DENSITY_BY_N pattern.
Sweep tooling: pcmci_alpha_sweep.py, aggregate_pcmci_sweep.py, submit_pcmci_alpha_sweep.sh.
Runtime-scaling experiment
runtime_scaling.py, submit_runtime_scaling{,_large}.sh, check_status.sh, aggregate_results.py

New harness to benchmark solver wall-time vs. graph size, with SLURM submission, a status monitor (queue state overrides stale error CSVs), and result aggregation.
BOLD simulation fixes: dense eigvals instead of ARPACK, retry with tighter input scaling on ragged output, dropped the W^n path-strength filter for large sparse N, and skip already-completed/queued jobs.
Clingo stats fix + diagnostics
benchmark_density_encoding.py, diagnose_subject_difficulty.py

Fixed choices/conflicts/restarts always reading 0 — wrong stats-tree path for clingo 5.7.1 (solving.solvers.* aggregate vs. per-thread solving.solver[i]). Added --stats=2 and a trajectory-based phase fingerprint (pre-first / descent / proof-tail). Confirmed default bb,lin wins and core-guided usc,oll is non-viable on these instances.
New diagnose_subject_difficulty.py to characterize per-subject solve difficulty.
Docs
CHANGELOG_AI.md (new), todo.md (expanded research backlog: per-SCC decomposition, GPU revisit, checkpoint warm-restart, weight-0 fact dropping, Bayesian MFAS weights), README.md.